### PR TITLE
fix: resolve airflow ModuleNotFoundError by correcting HOME path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,11 +57,11 @@ services:
         condition: service_healthy
     volumes:
       - ./dags:/opt/airflow/dags
-      - ${HOST_WORKSPACE_PATH}:${CONTAINER_HOME}/workspace
+      - ${HOST_WORKSPACE_PATH}:/home/airflow/workspace
       - /var/run/docker.sock:/var/run/docker.sock
-      - ${CLAUDE_CLI_BINARY}:${CONTAINER_HOME}/.local/bin/claude:ro
-      - ${CLAUDE_CONFIG_DIR}:${CONTAINER_HOME}/.claude
-      - ${CLAUDE_CREDENTIALS_FILE}:${CONTAINER_HOME}/.claude.json
+      - ${CLAUDE_CLI_BINARY}:/home/airflow/.local/bin/claude:ro
+      - ${CLAUDE_CONFIG_DIR}:/home/airflow/.claude
+      - ${CLAUDE_CREDENTIALS_FILE}:/home/airflow/.claude.json
     ports:
       - "8080:8080"
     environment:
@@ -74,7 +74,7 @@ services:
       AIRFLOW__SIMPLE_AUTH_MANAGER__ALL_ADMINS: "true"
       GITHUB_TOKEN: ${GITHUB_TOKEN}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
-      HOME: ${CONTAINER_HOME}
+      HOME: /home/airflow
 
   slack-bolt:
     image: ghcr.io/baekenough/customclaw-slack-bolt:latest


### PR DESCRIPTION
## Summary
- Root cause: `HOME=${CONTAINER_HOME}` (=/home/appuser) in airflow service causes Python to look for packages at wrong path
- Fix: Set `HOME=/home/airflow` and update volume mount targets to `/home/airflow/`
- Only the airflow service is modified; all other services remain unchanged

## Root Cause
The `apache/airflow:3.1.8-python3.12` base image installs airflow as user `airflow` with packages at `/home/airflow/.local/lib/python3.12/site-packages/`. Setting `HOME=/home/appuser` redirects Python's user site-packages lookup to `/home/appuser/.local/lib/...` which doesn't contain airflow.

## Test plan
- [ ] Verify `docker compose up airflow` starts without ModuleNotFoundError
- [ ] Verify Airflow API responds at :8080
- [ ] Verify DAGs can be triggered
- [ ] Verify Claude CLI is accessible from within the container

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)