### PR TITLE
chore: remove dead git-worker service (#23)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ customclaw/
 ├── docker/
 │   ├── airflow/              # Airflow Dockerfile + entrypoint
 │   ├── opensearch/           # OpenSearch image with nori plugin
-│   ├── slack-bolt/           # Shared image: slack-bolt, worker, git-worker
+│   ├── slack-bolt/           # Shared image: slack-bolt, worker
 │   └── web-ui/               # Next.js image
 ├── migrations/               # PostgreSQL migration SQL files (applied in order)
 ├── slack_bot/
@@ -143,7 +143,6 @@ customclaw/
 │   ├── docs_analyzer.py      # Documentation drift analysis consumer
 │   ├── supervisor.py         # Process supervisor (restart-on-exit-75)
 │   ├── runtime_control.py    # Redis-based restart signaling helpers
-│   ├── git_worker.py         # Git operations consumer (Phase 4 stub)
 │   ├── bot_runner.py         # Slack-specific message handler
 │   ├── config/
 │   │   └── loader.py         # YAML → BotConfig dataclass loader

--- a/FOR-AGENTS.md
+++ b/FOR-AGENTS.md
@@ -279,7 +279,7 @@ Web UI (Next.js): http://localhost:3000 — dashboard, bot management, monitorin
 | Aspect | Detail |
 |--------|--------|
 | Registry | GHCR (`ghcr.io/baekenough/customclaw-*`) |
-| Image naming | `customclaw-slack-bolt` (shared by slack-bolt, worker, git-worker), `customclaw-web-ui`, `customclaw-airflow`, `customclaw-opensearch` |
+| Image naming | `customclaw-slack-bolt` (shared by slack-bolt, worker), `customclaw-web-ui`, `customclaw-airflow`, `customclaw-opensearch` |
 | Auto-update | Watchtower (nickfedor/watchtower fork) checks for new images daily at 4:00 AM |
 | Override pattern | `docker-compose.override.yml` for local development (build from source) |
 
@@ -298,7 +298,6 @@ Web UI (Next.js): http://localhost:3000 — dashboard, bot management, monitorin
 | `airflow` | 8080 | DAG orchestration |
 | `slack-bolt` | — | Slack event listener |
 | `worker` | — | Message processor (Claude/Codex CLI) |
-| `git-worker` | — | Async git operations |
 | `web-ui` | 3000 | Dashboard |
 
 ## Common Operations

--- a/README.en.md
+++ b/README.en.md
@@ -114,7 +114,6 @@ customclaw/
 │   ├── analysis_worker.py       # Dedicated analysis Redis Stream consumer
 │   ├── supervisor.py            # Process supervisor for managed restarts
 │   ├── runtime_control.py       # Runtime control helpers (Redis-based restart)
-│   ├── git_worker.py            # Redis Stream consumer — handles async Git operations
 │   ├── bot_runner.py            # Per-bot Slack event handler and stream producer
 │   ├── config/
 │   │   └── loader.py            # YAML bot config loader (BotConfig dataclass)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ customclaw/
 │   ├── analysis_worker.py   # 분석 전용 Redis Stream 컨슈머
 │   ├── supervisor.py        # 프로세스 슈퍼바이저
 │   ├── runtime_control.py   # 런타임 제어 헬퍼
-│   ├── git_worker.py        # Git 작업 전용 워커
 │   ├── bot_runner.py        # 개별 봇 실행 로직
 │   ├── config/
 │   │   └── loader.py        # YAML → BotConfig 로더

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -17,11 +17,6 @@ services:
       context: .
       dockerfile: docker/slack-bolt/Dockerfile
 
-  git-worker:
-    build:
-      context: .
-      dockerfile: docker/slack-bolt/Dockerfile
-
   web-ui:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,22 +143,6 @@ services:
       CREDENTIAL_ALERT_CHANNEL: ${CREDENTIAL_ALERT_CHANNEL:-C0AMBNY135Z}
     command: python -m bot_engine.worker
 
-  git-worker:
-    image: ghcr.io/baekenough/customclaw-slack-bolt:latest
-    restart: unless-stopped
-    stop_grace_period: 120s
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
-      - "com.centurylinklabs.watchtower.scope=customclaw"
-    depends_on:
-      redis:
-        condition: service_healthy
-    volumes:
-      - repos:${CONTAINER_HOME}/workspace
-    environment:
-      REDIS_URL: redis://redis:6379
-    command: python -m bot_engine.git_worker
-
   web-ui:
     image: ghcr.io/baekenough/customclaw-web-ui:latest
     restart: unless-stopped

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -40,27 +40,15 @@ flowchart LR
     MEM -.->|pgvector HNSW\nfuture| W
 ```
 
-### 2.3 Git Worker (Redis Stream)
-
-```mermaid
-flowchart LR
-    W[Worker / other producers] -->|xadd customclaw:git-ops| GS[(Redis Stream\ncustomclaw:git-ops)]
-    GS -->|xreadgroup| GW[git-worker\nPhase 4 stub]
-    GW -->|git clone / push / PR| GH([GitHub API])
-    GW -->|operate on| REPO[shared workspace volume]
-```
-
-> **Note:** git-worker is currently a stub pending Phase 4 implementation. The Redis stream infrastructure is in place.
-
-### 2.4 Airflow DAG Processing
+### 2.3 Airflow DAG Processing
 
 <p align="center"><img src="../assets/diagrams/08-dag-pipeline.png" width="800" /></p>
 
-### 2.5 Web UI
+### 2.4 Web UI
 
 <p align="center"><img src="../assets/diagrams/07-web-ui.png" width="800" /></p>
 
-### 2.6 Full Service Topology
+### 2.5 Full Service Topology
 
 <p align="center"><img src="../assets/diagrams/01-system-architecture.png" width="800" /></p>
 
@@ -136,13 +124,7 @@ sequenceDiagram
 
 **Post-processing**: after sending the reply, `MemoryExtractor.extract_and_store` is called asynchronously (best-effort, non-blocking) to mine facts, decisions, and preferences from the conversation.
 
-### 3.3 Git Worker (`git_worker.py`)
-
-Currently a Phase 4 stub for general async git operations. The worker subscribes to a Redis Stream for git operation events. Full implementation will handle `git clone`, `git push`, branch management, and PR creation via GitHub API, operating on the `repos` shared volume.
-
-> **Note:** The `worker` container image now includes `git` and the `gh` CLI, which are required by the `omcustom-driver` auto-development pipeline (see section 3.9).
-
-### 3.4 Memory System
+### 3.3 Memory System
 
 <p align="center"><img src="../assets/diagrams/04-memory-extraction.png" width="800" /></p>
 
@@ -161,7 +143,7 @@ Currently a Phase 4 stub for general async git operations. The worker subscribes
 
 **Memory categories:** `fact`, `decision`, `preference`
 
-### 3.5 Tool System
+### 3.4 Tool System
 
 <p align="center"><img src="../assets/diagrams/05-tool-class.png" width="800" /></p>
 
@@ -176,7 +158,7 @@ Tools are passed to Claude via formatted prompt text (not native Anthropic tool-
 
 Per-bot tool access is controlled by `tools.enabled` in the bot YAML config.
 
-### 3.6 Bot Configuration (`config/loader.py`)
+### 3.5 Bot Configuration (`config/loader.py`)
 
 Bot configurations are loaded from YAML files in `/app/bots/`. Each file maps to a `BotConfig` dataclass with the following sections:
 
@@ -194,7 +176,7 @@ Bot configurations are loaded from YAML files in `/app/bots/`. Each file maps to
 
 Environment variable references in the form `${VAR_NAME}` are resolved at load time.
 
-### 3.7 Web UI (`web-ui/`)
+### 3.6 Web UI (`web-ui/`)
 
 Built with Next.js 16 (App Router), TypeScript, and Prisma ORM.
 
@@ -215,7 +197,7 @@ Built with Next.js 16 (App Router), TypeScript, and Prisma ORM.
 | `/api/usage` | GET | API token usage summary |
 | `/api/health` | GET | Service health (PostgreSQL, Redis, OpenSearch, Airflow) |
 
-### 3.8 Airflow DAGs
+### 3.7 Airflow DAGs
 
 **`omc_issue_analyzer`** — 4-Phase Analysis Pipeline
 
@@ -298,7 +280,7 @@ Scheduled DAG (`0 */3 * * *` — every 3 hours) that polls official documentatio
 
 Minimal example DAG included for Airflow connectivity testing.
 
-### 3.9 omcustom-driver (Auto-Development Agent)
+### 3.8 omcustom-driver (Auto-Development Agent)
 
 The `omcustom-driver` is an autonomous development agent that activates only when the Professor approves a GitHub issue for automated development.
 
@@ -321,7 +303,7 @@ The `omcustom-driver` is an autonomous development agent that activates only whe
 
 The analysis consumer uses `xautoclaim` recovery to reclaim unacknowledged messages after a configurable idle timeout, preventing message loss when the consumer restarts.
 
-### 3.10 Analysis Worker (`analysis_worker.py`)
+### 3.9 Analysis Worker (`analysis_worker.py`)
 
 A dedicated Redis Stream consumer that processes PR analysis and issue analysis requests independently from the main message worker.
 
@@ -343,7 +325,7 @@ A dedicated Redis Stream consumer that processes PR analysis and issue analysis 
 - Redis distributed lock (`SET NX EX`, 15-min TTL) prevents duplicate analysis of same PR
 - Slack message threading keeps analysis updates organized per PR
 
-### 3.11 Process Management (`supervisor.py` / `runtime_control.py`)
+### 3.10 Process Management (`supervisor.py` / `runtime_control.py`)
 
 `supervisor.py` is a process supervisor that manages worker/app restarts. `runtime_control.py` provides Redis-based helpers for safe self-restart requests.
 
@@ -358,7 +340,7 @@ A dedicated Redis Stream consumer that processes PR analysis and issue analysis 
 - `CUSTOMCLAW_SUPERVISED` environment variable indicates supervised mode
 - `CUSTOMCLAW_RUNTIME_TARGET` specifies which module to supervise
 
-### 3.12 GitHub Actions Workflows (`workflows/`)
+### 3.11 GitHub Actions Workflows (`workflows/`)
 
 | Workflow | File | Trigger | Description |
 |----------|------|---------|-------------|
@@ -522,14 +504,13 @@ Token usage tracking per bot invocation.
 | `airflow` | `customclaw-airflow` | 8080 | `dags/`, workspace | DAG scheduler + webserver |
 | `slack-bolt` | `customclaw-slack-bolt` | — | `bots/`, `repos` | Platform adapter event ingestion (Slack / Discord) |
 | `worker` | `customclaw-slack-bolt` | — | `bots/`, `repos`, Claude/Codex auth | AI response processing |
-| `git-worker` | `customclaw-slack-bolt` | — | `repos` | Git operations (Phase 4 stub) |
 | `web-ui` | `customclaw-web-ui` | 3000 | — | Management web interface |
 | `claude-analyzer` | `customclaw-slack-bolt` | — | Claude auth, workspace | Docs drift analysis — Claude CLI sonnet |
 | `codex-analyzer` | `customclaw-slack-bolt` | — | Codex auth, workspace | Docs drift analysis — Codex CLI gpt-5.4 |
 | `gemini-analyzer` | `customclaw-slack-bolt` | — | Gemini auth, workspace | Docs drift analysis — Gemini CLI 3 Pro Preview |
 | `watchtower` | `nickfedor/watchtower` | — | Docker socket | Optional auto-update (profile: `auto-update`) |
 
-Total: 12 services (11 always-on + 1 optional profile)
+Total: 11 services (10 always-on + 1 optional profile)
 
 The three analyzer services (`claude-analyzer`, `codex-analyzer`, `gemini-analyzer`) consume from dedicated Redis Streams (`customclaw:claude-analysis`, `customclaw:codex-analysis`, `customclaw:gemini-analysis`) published by the `agentnav_issue_analyzer` DAG. Each runs `bot_engine.docs_analyzer` with a different CLI backend.
 
@@ -540,7 +521,7 @@ The three analyzer services (`claude-analyzer`, `codex-analyzer`, `gemini-analyz
 | `pgdata` | postgres | PostgreSQL data files |
 | `osdata` | opensearch | OpenSearch index data |
 | `redisdata` | redis | Redis AOF persistence |
-| `repos` | airflow, slack-bolt, worker, git-worker | Cloned git repositories (shared) |
+| `repos` | airflow, slack-bolt, worker | Cloned git repositories (shared) |
 
 ### 6.3 Host Bind Mounts (Worker)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,11 +58,7 @@ Redis Consumer Group(`customclaw-workers`) 방식으로 메시지를 소비합�
 | `claude.full_agent` | full_agent 모드 활성화 |
 | `memory.context_window` | 대화 이력 불러올 메시지 수 (기본 20) |
 
-### 3.3 Git Worker (git_worker.py)
-
-현재 Phase 4 구현 대기 중인 스텁(stub) 상태입니다. 향후 Redis Stream에서 Git 작업 요청을 소비하고 `repos` 볼륨에 마운트된 워크스페이스에서 Git 명령을 실행할 예정입니다.
-
-### 3.4 메모리 시스템
+### 3.3 메모리 시스템
 
 <p align="center"><img src="../assets/diagrams/04-memory-extraction.png" width="800" /></p>
 
@@ -72,7 +68,7 @@ Redis Consumer Group(`customclaw-workers`) 방식으로 메시지를 소비합�
 - 추출은 대화 4개 메시지 이상 누적 시 Claude haiku(`--max-turns 1`)로 자동 실행됩니다.
 - RRF(Reciprocal Rank Fusion)로 두 검색 결과를 병합하는 코드는 TODO 상태입니다.
 
-### 3.5 도구 시스템 (tools/)
+### 3.4 도구 시스템 (tools/)
 
 <p align="center"><img src="../assets/diagrams/05-tool-class.png" width="800" /></p>
 
@@ -86,13 +82,13 @@ Redis Consumer Group(`customclaw-workers`) 방식으로 메시지를 소비합�
 
 총 12개 도구. 봇별 `tools.enabled` 설정으로 허용할 도구 집합을 제한할 수 있습니다.
 
-### 3.6 봇 설정 (config/loader.py)
+### 3.5 봇 설정 (config/loader.py)
 
 봇 설정은 YAML 파일(`/app/bots/*.yaml`) 또는 PostgreSQL `bots` 테이블에서 로드됩니다. 환경 변수 레퍼런스(`${ENV_VAR}` 형식)는 자동으로 확장됩니다. `platform` 필드로 `slack` / `mattermost` / `discord` 중 하나를 지정합니다.
 
 <p align="center"><img src="../assets/diagrams/06-bot-config.png" width="800" /></p>
 
-### 3.7 Web UI (Next.js 16)
+### 3.6 Web UI (Next.js 16)
 
 <p align="center"><img src="../assets/diagrams/07-web-ui.png" width="800" /></p>
 
@@ -100,7 +96,7 @@ Redis Consumer Group(`customclaw-workers`) 방식으로 메시지를 소비합�
 - **Airflow 프록시**: 매 요청마다 `/auth/token` 엔드포인트에서 JWT를 발급받아 `Authorization: Bearer` 헤더로 Airflow API를 호출합니다.
 - **헬스 체크**: PostgreSQL, Redis, OpenSearch, Airflow 4개 서비스를 병렬(`Promise.allSettled`)로 확인합니다. 하나라도 실패하면 HTTP 503을 반환합니다.
 
-### 3.8 Airflow DAGs
+### 3.7 Airflow DAGs
 
 <p align="center"><img src="../assets/diagrams/08-dag-pipeline.png" width="800" /></p>
 
@@ -116,7 +112,7 @@ Redis Consumer Group(`customclaw-workers`) 방식으로 메시지를 소비합�
 | `docs_drift_monitor` | `0 */3 * * *` (3시간 주기) | Claude Code·Codex·Gemini CLI 공식 문서 변경 감지 → GitHub docs-drift 이슈 생성 → agentnav_issue_analyzer 트리거 |
 | `example_hello_world` | 수동 / 스케줄러 | Airflow 동작 확인용 예제 DAG |
 
-### 3.9 omcustom-driver (자동 개발 에이전트)
+### 3.8 omcustom-driver (자동 개발 에이전트)
 
 Professor가 `auto-dev` 판단을 내린 이슈에 한해 활성화되는 자동 개발 파이프라인입니다.
 
@@ -142,7 +138,7 @@ omcustom-driver는 git 및 gh CLI가 필요합니다. worker 컨테이너 이미
 - `oh-my-customcode` 저장소의 `issue-comment-reeval.yml`이 `needs-input` 라벨이 붙은 이슈에 새 코멘트가 달리면 SSH를 통해 `omc_issue_analyzer` DAG를 재트리거합니다.
 - Analysis consumer는 xautoclaim 복구 기능을 갖추고 있어 재시작 시 메시지 유실을 방지합니다.
 
-### 3.10 Analysis Worker (analysis_worker.py)
+### 3.9 Analysis Worker (analysis_worker.py)
 
 PR 분석 및 이슈 분석 요청을 처리하는 별도의 Redis Stream 컨슈머입니다.
 
@@ -152,7 +148,7 @@ PR 분석 및 이슈 분석 요청을 처리하는 별도의 Redis Stream 컨슈
 - **중복 방지**: Redis `SET NX EX` 분산 락으로 동일 PR 15분 내 중복 분석 차단
 - **복구**: `xautoclaim`으로 미확인 메시지 자동 복구
 
-### 3.11 프로세스 관리 (supervisor.py / runtime_control.py)
+### 3.10 프로세스 관리 (supervisor.py / runtime_control.py)
 
 `supervisor.py`는 worker/app 프로세스의 관리형 재시작을 지원하는 프로세스 슈퍼바이저입니다. `runtime_control.py`는 Redis 기반 안전한 자체 재시작 요청 헬퍼를 제공합니다.
 
@@ -160,7 +156,7 @@ PR 분석 및 이슈 분석 요청을 처리하는 별도의 Redis Stream 컨슈
 - 종료 코드 75로 프로세스 종료 시 슈퍼바이저가 자동 재시작
 - `CUSTOMCLAW_SUPERVISED` 환경 변수로 슈퍼바이저 모드 감지
 
-### 3.12 GitHub Actions 워크플로우 (workflows/)
+### 3.11 GitHub Actions 워크플로우 (workflows/)
 
 | 워크플로우 | 파일 | 설명 |
 |-----------|------|------|
@@ -242,7 +238,7 @@ PR 분석 및 이슈 분석 요청을 처리하는 별도의 Redis Stream 컨슈
 | 볼륨/경로 | 서비스 | 목적 |
 |-----------|--------|------|
 | `./bots:/app/bots` | slack-bolt, worker | 봇 YAML 설정 파일 실시간 반영 |
-| `repos:${CONTAINER_HOME}/workspace` | slack-bolt, worker, git-worker, airflow | Git 리포지토리 공유 |
+| `repos:${CONTAINER_HOME}/workspace` | slack-bolt, worker, airflow | Git 리포지토리 공유 |
 | `${CLAUDE_CONFIG_DIR}:${CLAUDE_CONFIG_DIR}` | worker | Claude CLI 설정·인증 |
 | `${CLAUDE_CREDENTIALS_FILE}` | worker | Claude CLI 자격증명 |
 | `${CLAUDE_CLI_BINARY}:/usr/local/bin/claude:ro` | worker | Claude CLI 바이너리 |

--- a/docs/superpowers/specs/2026-03-18-customclaw-design.md
+++ b/docs/superpowers/specs/2026-03-18-customclaw-design.md
@@ -20,7 +20,6 @@ External → Reverse proxy / tunnel → http://<your-host>:3000
 | **Airflow** | apache/airflow:3.0.1 | Scheduled tasks (release monitoring, issue analysis) |
 | **slack-bolt** | Python (slack-bolt) | Slack event listener, message routing |
 | **worker** | Python + Claude/Codex CLI | LLM execution, conversation processing |
-| **git-worker** | Python | Repository sync operations via Redis queue |
 | **web-ui** | Next.js 16, shadcn/ui | Admin dashboard, bot management |
 
 ### Data Flow


### PR DESCRIPTION
## Summary

- Remove dead `git-worker` service that was never operational after `git_worker.py` was deleted in PR #14
- Docker Compose and all documentation still referenced the service, causing container restart loops (issue #23)
- Cleans up 9 files: docker-compose configs and all documentation

## Files Changed (9 files)

| File | Change |
|------|--------|
| `docker-compose.yml` | Remove `git-worker` service definition |
| `docker-compose.override.yml.example` | Remove `git-worker` override section |
| `README.md` | Remove git-worker references |
| `README.en.md` | Remove git-worker references |
| `docs/architecture.md` | Remove git-worker, renumber affected sections |
| `docs/architecture.en.md` | Remove git-worker, renumber affected sections |
| `FOR-AGENTS.md` | Remove git-worker references |
| `CONTRIBUTING.md` | Remove git-worker references |
| `docs/superpowers/specs/2026-03-18-customclaw-design.md` | Remove git-worker from design spec |

## Test Plan

- [ ] Run `docker compose config` — verify no validation errors
- [ ] Grep for remaining `git-worker` references: `grep -r "git.worker\|git_worker" . --exclude-dir=.git`
- [ ] Verify docker compose up starts cleanly without restart loops

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)