### PR TITLE
feat: hot-reload bot config via Redis Pub/Sub (#24)

### DIFF
--- a/bot_engine/config/hot_reload.py
+++ b/bot_engine/config/hot_reload.py
@@ -1,0 +1,69 @@
+"""Hot-reload config subscriber via Redis Pub/Sub."""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Callable
+
+import redis
+
+log = logging.getLogger(__name__)
+
+CONFIG_CHANNEL = "customclaw:bot-config-changed"
+
+
+def start_config_subscriber(
+    redis_url: str,
+    on_reload: Callable[[str], None],
+) -> threading.Thread:
+    """Start a daemon thread that subscribes to config change events.
+
+    Uses a dedicated Redis connection for Pub/Sub (Redis requirement).
+    Calls on_reload(bot_id) when a config change event is received.
+    Reconnects automatically on connection loss.
+    """
+
+    def _listen() -> None:
+        while True:
+            try:
+                r = redis.from_url(redis_url)
+                pubsub = r.pubsub()
+                pubsub.subscribe(CONFIG_CHANNEL)
+                log.info(
+                    "Config hot-reload subscriber started on channel: %s",
+                    CONFIG_CHANNEL,
+                )
+
+                for message in pubsub.listen():
+                    if message["type"] != "message":
+                        continue
+                    bot_id = message["data"]
+                    if isinstance(bot_id, bytes):
+                        bot_id = bot_id.decode()
+                    log.info("Config reload event received for bot: %s", bot_id)
+                    try:
+                        on_reload(bot_id)
+                    except Exception:
+                        log.exception(
+                            "Error during config hot-reload for bot: %s", bot_id
+                        )
+            except redis.ConnectionError:
+                log.warning(
+                    "Config subscriber lost Redis connection, reconnecting in 5s..."
+                )
+                time.sleep(5)
+            except Exception:
+                log.exception(
+                    "Config subscriber unexpected error, restarting in 5s..."
+                )
+                time.sleep(5)
+
+    thread = threading.Thread(target=_listen, name="config-hot-reload", daemon=True)
+    thread.start()
+    return thread
+
+
+def publish_config_change(redis_client: redis.Redis, bot_id: str) -> None:
+    """Publish a config change event. Called by bot management tools."""
+    redis_client.publish(CONFIG_CHANNEL, bot_id)

--- a/bot_engine/tools/bot_management_tools.py
+++ b/bot_engine/tools/bot_management_tools.py
@@ -21,15 +21,10 @@ def _get_db_conn():
 
 
 def _notify_hot_reload(bot_id: str) -> None:
-    """Notify config change and request runtime restarts."""
+    """Notify config change via Pub/Sub. Worker hot-reloads; app restarts."""
     redis_url = os.environ.get("REDIS_URL", "redis://redis:6379")
     r = redis.from_url(redis_url)
     r.publish("customclaw:bot-config-changed", bot_id)
-    request_restart(
-        "worker",
-        requested_by="bot_config_changed",
-        reason=f"bot:{bot_id}",
-    )
     request_restart(
         "app",
         requested_by="bot_config_changed",

--- a/bot_engine/worker.py
+++ b/bot_engine/worker.py
@@ -1306,6 +1306,24 @@ def main():
         merge_window=MERGE_WINDOW,
     )
 
+    # Hot-reload config on Pub/Sub event (no restart needed)
+    from bot_engine.config.hot_reload import start_config_subscriber
+
+    def _reload_config(bot_id: str) -> None:
+        nonlocal bots
+        log.info("Hot-reloading bot configs (triggered by: %s)...", bot_id)
+        new_configs = load_all_bots(bots_dir)
+        new_bots = {c.id: c for c in new_configs}
+        bots = new_bots
+        dispatcher._bots = new_bots
+        _publisher_cache.clear()
+        # Clear analysis_worker cached bot info
+        from bot_engine import analysis_worker
+        analysis_worker._cached_bot_info = None
+        log.info("Hot-reload complete: %d bot(s) loaded", len(new_bots))
+
+    start_config_subscriber(redis_url, _reload_config)
+
     # Start analysis request consumer in background
     start_analysis_consumer(redis_client)
 


### PR DESCRIPTION
## Summary

- Adds Redis Pub/Sub config hot-reload to eliminate worker restarts when bot config changes
- New `bot_engine/config/hot_reload.py` provides a reusable subscriber with auto-reconnect on connection loss
- Worker integrates the subscriber in its main loop, reloading configs and clearing caches on change events

## Architecture

```
Publish side (bot_management_tools.py — already existed)
  └─ publishes bot config change event to Redis channel
       ↓
Subscriber (worker.py — new integration)
  └─ hot_reload.py listener triggers reload callback
       ↓
Reload callback
  ├─ Clears publisher cache
  ├─ Reloads bot configs from DB
  └─ Resets analysis_worker cached credentials
```

## Files Changed

- **NEW** `bot_engine/config/hot_reload.py` — reusable Pub/Sub subscriber with auto-reconnect
- **MODIFIED** `bot_engine/worker.py` — integrate hot-reload subscriber in main loop
- **MODIFIED** `bot_engine/tools/bot_management_tools.py` — remove worker restart request (now handled by hot-reload), keep app restart for socket connections

## Test Plan

- [ ] Change a bot config via management tool
- [ ] Verify worker logs show "Hot-reload complete" (no service restart)
- [ ] Verify bot operates with updated config immediately after reload
- [ ] Simulate Redis connection loss → verify auto-reconnect and resumed hot-reload

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)