### PR TITLE
fix: eliminate shell injection in subprocess calls

### DIFF
--- a/bot_engine/analysis_worker.py
+++ b/bot_engine/analysis_worker.py
@@ -7,7 +7,6 @@ import os
 import re
 import socket
 import subprocess
-import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -602,29 +601,35 @@ def _run_analysis(
     model = "opus"
     max_turns = "30"
 
-    prompt_file = None
     try:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write(prompt)
-            prompt_file = f.name
-
         # Use repo_path if it exists, else fall back to /tmp
         cwd = repo_path if os.path.isdir(repo_path) else "/tmp"
 
         # Pull latest code before analysis to avoid stale code issues
-        pull_cmd = f"cd {cwd} && git pull --ff-only origin main 2>/dev/null || true"
-        subprocess.run(pull_cmd, shell=True, capture_output=True, timeout=30)
+        try:
+            subprocess.run(
+                ["git", "-C", cwd, "pull", "--ff-only", "origin", "main"],
+                capture_output=True,
+                timeout=30,
+            )
+        except Exception:
+            pass  # Best-effort pull, don't block analysis
 
-        cmd = (
-            f"NO_COLOR=1 HOME={os.environ.get('CONTAINER_HOME', '/home/appuser')} "
-            f"{CLAUDE_CLI_PATH} -p \"$(cat {prompt_file})\" "
-            f"--model {model} --max-turns {max_turns} "
-            f"--allowedTools {allowed_tools}"
-        )
+        env = {
+            **os.environ,
+            "HOME": os.environ.get("CONTAINER_HOME", "/home/appuser"),
+            "NO_COLOR": "1",
+        }
+        args = [
+            CLAUDE_CLI_PATH, "-p", prompt,
+            "--model", model,
+            "--max-turns", str(max_turns),
+            "--allowedTools", allowed_tools,
+        ]
 
         result = subprocess.run(
-            cmd,
-            shell=True,
+            args,
+            env=env,
             capture_output=True,
             text=True,
             timeout=600,  # 10 min max
@@ -659,9 +664,6 @@ def _run_analysis(
     except Exception as e:
         log.error("Analysis error for #%s (%s): %s", issue_number, analysis_type, e)
         return None
-    finally:
-        if prompt_file and os.path.exists(prompt_file):
-            os.unlink(prompt_file)
 
 
 def _post_github_comment(repo: str, issue_number: str, body: str) -> bool:

--- a/bot_engine/memory/extractor.py
+++ b/bot_engine/memory/extractor.py
@@ -7,7 +7,6 @@ import logging
 import os
 import re
 import subprocess
-import tempfile
 import uuid
 
 import psycopg2
@@ -197,22 +196,19 @@ class MemoryExtractor:
 
         Returns raw output string or None on failure.
         """
-        prompt_file = None
         try:
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".txt", delete=False
-            ) as f:
-                f.write(prompt)
-                prompt_file = f.name
-
-            cmd = (
-                f"NO_COLOR=1 HOME={os.environ.get('CONTAINER_HOME', '/home/appuser')} "
-                f"{CLAUDE_CLI_PATH} -p \"$(cat {prompt_file})\" "
-                f"--model haiku --max-turns 1"
-            )
+            env = {
+                **os.environ,
+                "HOME": os.environ.get("CONTAINER_HOME", "/home/appuser"),
+                "NO_COLOR": "1",
+            }
             result = subprocess.run(
-                cmd,
-                shell=True,
+                [
+                    CLAUDE_CLI_PATH, "-p", prompt,
+                    "--model", "haiku",
+                    "--max-turns", "1",
+                ],
+                env=env,
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -224,9 +220,6 @@ class MemoryExtractor:
         except Exception as e:
             log.warning("Claude CLI extraction failed: %s", e)
             return None
-        finally:
-            if prompt_file and os.path.exists(prompt_file):
-                os.unlink(prompt_file)
 
     def _parse_extraction(self, text: str) -> list[dict]:
         """Parse JSON array from Claude's response.

--- a/bot_engine/tools/code_tools.py
+++ b/bot_engine/tools/code_tools.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
-import tempfile
 
 from bot_engine.tools.base import BaseTool, ToolDefinition, ToolResult
 
@@ -39,20 +38,19 @@ class SearchCodeTool(BaseTool):
             return ToolResult(content=f"Repo path does not exist: {repo_path}", is_error=True)
 
         claude_cli = os.environ.get("CLAUDE_CLI_PATH", "claude")
-        prompt_file = None
         try:
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-                f.write(query)
-                prompt_file = f.name
-
-            cmd = (
-                f'NO_COLOR=1 {claude_cli} -p "$(cat {prompt_file})" '
-                f'--model sonnet --max-turns {max_turns} '
-                f'--allowedTools Read,Glob,Grep'
-            )
+            env = {
+                **os.environ,
+                "NO_COLOR": "1",
+            }
             result = subprocess.run(
-                cmd,
-                shell=True,
+                [
+                    claude_cli, "-p", query,
+                    "--model", "sonnet",
+                    "--max-turns", str(max_turns),
+                    "--allowedTools", "Read,Glob,Grep",
+                ],
+                env=env,
                 capture_output=True,
                 text=True,
                 timeout=max_turns * 60,
@@ -81,6 +79,3 @@ class SearchCodeTool(BaseTool):
             )
         except Exception as e:
             return ToolResult(content=f"Code search failed: {e}", is_error=True)
-        finally:
-            if prompt_file and os.path.exists(prompt_file):
-                os.unlink(prompt_file)

--- a/bot_engine/worker.py
+++ b/bot_engine/worker.py
@@ -11,7 +11,6 @@ import re
 import socket
 import sys
 import subprocess
-import tempfile
 import threading
 import time
 
@@ -338,13 +337,8 @@ def _run_claude_cli(
 
     Returns ``(None, None)`` on timeout, non-zero exit code, or empty output.
     """
-    prompt_file = None
     timeout = 180  # default; overridden based on mode below
     try:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write(prompt)
-            prompt_file = f.name
-
         model_map = {
             "opus": "opus",
             "sonnet": "sonnet",
@@ -352,29 +346,28 @@ def _run_claude_cli(
         }
         cli_model = model_map.get(model, model)
 
+        env = {
+            **os.environ,
+            "HOME": os.environ.get("CONTAINER_HOME", "/home/appuser"),
+            "NO_COLOR": "1",
+        }
+
+        base_args = [
+            CLAUDE_CLI_PATH, "-p", prompt,
+            "--model", cli_model,
+            "--max-turns", str(max_turns),
+            "--output-format", "json",
+        ]
+
         if full_agent:
-            # Full agent mode: high turns, all built-in tools available
-            cmd = (
-                f"NO_COLOR=1 HOME={os.environ.get('CONTAINER_HOME', '/home/appuser')} "
-                f"{CLAUDE_CLI_PATH} -p \"$(cat {prompt_file})\" "
-                f"--model {cli_model} --max-turns {max_turns} "
-                f"--output-format json "
-                f"--dangerously-skip-permissions"
-            )
-            timeout = max_turns * 60  # 1 min per turn
+            base_args.append("--dangerously-skip-permissions")
+            timeout = max_turns * 60
         else:
-            # Limited prompt mode
-            cmd = (
-                f"NO_COLOR=1 HOME={os.environ.get('CONTAINER_HOME', '/home/appuser')} "
-                f"{CLAUDE_CLI_PATH} -p \"$(cat {prompt_file})\" "
-                f"--model {cli_model} --max-turns {max_turns} "
-                f"--output-format json"
-            )
             timeout = 180
 
         result = subprocess.run(
-            cmd,
-            shell=True,
+            base_args,
+            env=env,
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -405,9 +398,6 @@ def _run_claude_cli(
     except Exception as e:
         log.error("Unexpected error running %s: %s", _provider_label("claude"), e)
         return None, None
-    finally:
-        if prompt_file and os.path.exists(prompt_file):
-            os.unlink(prompt_file)
 
 
 def _run_codex_cli(
@@ -518,6 +508,10 @@ def _execute_tool(
     tool = registry.get(tool_name)
     if not tool:
         return f"Unknown tool: {tool_name}"
+
+    # Enforce dangerous_tools restriction
+    if tool_name in (config.security.dangerous_tools or []):
+        return f"Tool '{tool_name}' is restricted by bot security configuration"
 
     extra: dict = {}
     if tool_name in ("create_issue", "query_issues"):
@@ -1270,9 +1264,10 @@ def main():
 
     # Verify Claude CLI availability at startup
     try:
+        env = {**os.environ, "HOME": os.environ.get("CONTAINER_HOME", "/home/appuser")}
         check = subprocess.run(
-            f"HOME={os.environ.get('CONTAINER_HOME', '/home/appuser')} {CLAUDE_CLI_PATH} --version",
-            shell=True,
+            [CLAUDE_CLI_PATH, "--version"],
+            env=env,
             capture_output=True,
             text=True,
             timeout=10,
@@ -1285,8 +1280,7 @@ def main():
     # Verify Codex CLI availability
     try:
         check = subprocess.run(
-            f"{CODEX_CLI_PATH} --version",
-            shell=True,
+            [CODEX_CLI_PATH, "--version"],
             capture_output=True,
             text=True,
             timeout=10,


### PR DESCRIPTION
## Summary

- Replace all `shell=True` subprocess invocations with safe list-form arguments across 4 files (7 call sites)
- Enforce `dangerous_tools` security config that was previously declared but never checked at dispatch time
- Remove tempfile indirection — prompts now passed directly via `-p` flag

## Files Changed (4)

| File | Change |
|------|--------|
| `bot_engine/worker.py` | `_run_claude_cli` list-form args + env dict; CLI version checks; `dangerous_tools` dispatch guard |
| `bot_engine/analysis_worker.py` | `git pull` uses `git -C` flag; `_run_analysis` list-form args |
| `bot_engine/tools/code_tools.py` | `SearchCodeTool` list-form args |
| `bot_engine/memory/extractor.py` | Claude CLI extraction list-form args |

## Test Plan

- [ ] Run worker integration tests with a sample task to verify subprocess calls succeed without shell
- [ ] Verify `dangerous_tools` config blocks disallowed tools (e.g., set a tool as dangerous, confirm it's rejected)
- [ ] Confirm `git pull` works in analysis worker with the `-C` flag approach
- [ ] Smoke test `SearchCodeTool` and memory extractor end-to-end
- [ ] Check that no `shell=True` remains: `grep -r "shell=True" bot_engine/`

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)