### PR TITLE
fix: v0.3.2 — P1 bot config and dashboard bugs

### DIFF
--- a/go/internal/config/loader.go
+++ b/go/internal/config/loader.go
@@ -134,7 +134,7 @@ func LoadBotFromYAML(path string) (*BotConfig, error) {
 		Claude: ClaudeConfig{
 			Provider:  stringField(raw.Claude, "provider"),
 			Model:     stringField(raw.Claude, "model"),
-			MaxTurns:  intField(raw.Claude, "max_turns", 10),
+			MaxTurns:  intField(raw.Claude, "max_turns", 5),
 			FullAgent: boolField(raw.Claude, "full_agent", false),
 		},
 		Memory: MemoryConfig{
@@ -255,7 +255,7 @@ func scanBotRow(rows pgx.Rows) (*BotConfig, error) {
 		Claude: ClaudeConfig{
 			Provider:  stringField(claude, "provider"),
 			Model:     stringField(claude, "model"),
-			MaxTurns:  intField(claude, "max_turns", 10),
+			MaxTurns:  intField(claude, "max_turns", 5),
 			FullAgent: boolField(claude, "full_agent", false),
 		},
 		Memory: MemoryConfig{

--- a/go/internal/config/types.go
+++ b/go/internal/config/types.go
@@ -91,7 +91,7 @@ func (c *BotConfig) defaults() {
 		c.Claude.Model = "sonnet"
 	}
 	if c.Claude.MaxTurns == 0 {
-		c.Claude.MaxTurns = 10
+		c.Claude.MaxTurns = 5
 	}
 	if c.Memory.ContextWindow == 0 {
 		c.Memory.ContextWindow = 20

--- a/go/internal/config/types_test.go
+++ b/go/internal/config/types_test.go
@@ -16,7 +16,7 @@ func TestBotConfigDefaults_ZeroValue(t *testing.T) {
 		{"Platform", cfg.Platform, "slack"},
 		{"Claude.Provider", cfg.Claude.Provider, "claude"},
 		{"Claude.Model", cfg.Claude.Model, "sonnet"},
-		{"Claude.MaxTurns", cfg.Claude.MaxTurns, 10},
+		{"Claude.MaxTurns", cfg.Claude.MaxTurns, 5},
 		{"Memory.ContextWindow", cfg.Memory.ContextWindow, 20},
 		{"Mattermost.Port", cfg.Mattermost.Port, 8065},
 	}

--- a/web-ui/src/app/(auth)/bots/[id]/page.tsx
+++ b/web-ui/src/app/(auth)/bots/[id]/page.tsx
@@ -94,9 +94,9 @@ export default function BotDetailPage({
   const [githubRepo, setGithubRepo] = useState("");
   const [provider, setProvider] = useState<"claude" | "codex">("claude");
   const [model, setModel] = useState("");
-  const [maxTurns, setMaxTurns] = useState(10);
+  const [maxTurns, setMaxTurns] = useState(5);
   const [fullAgent, setFullAgent] = useState(false);
-  const [contextWindow, setContextWindow] = useState(50000);
+  const [contextWindow, setContextWindow] = useState(20);
   const [autoExtract, setAutoExtract] = useState(true);
   const [enabledTools, setEnabledTools] = useState<string[]>([]);
   const [dangerousTools, setDangerousTools] = useState<string[]>([]);
@@ -119,9 +119,9 @@ export default function BotDetailPage({
         setGithubRepo(data.project?.github_repo ?? "");
         setProvider((data.claude?.provider as "claude" | "codex") ?? "claude");
         setModel(data.claude?.model ?? "claude-opus-4-5");
-        setMaxTurns(data.claude?.max_turns ?? 10);
+        setMaxTurns(data.claude?.max_turns ?? 5);
         setFullAgent(data.claude?.full_agent ?? false);
-        setContextWindow(data.memory?.context_window ?? 50000);
+        setContextWindow(data.memory?.context_window ?? 20);
         setAutoExtract(data.memory?.auto_extract ?? true);
         setEnabledTools(data.tools?.enabled ?? []);
         setDangerousTools(data.security?.dangerous_tools ?? []);
@@ -450,18 +450,18 @@ export default function BotDetailPage({
                   min={1}
                   max={100}
                   value={maxTurns}
-                  onChange={(e) => setMaxTurns(parseInt(e.target.value) || 10)}
+                  onChange={(e) => setMaxTurns(parseInt(e.target.value) || 5)}
                   className="h-9 text-sm"
                 />
               </div>
               <div className="space-y-2">
-                <Label className="text-xs">컨텍스트 윈도우</Label>
+                <Label className="text-xs">컨텍스트 윈도우 (최근 메시지 수)</Label>
                 <Input
                   type="number"
-                  min={1000}
+                  min={1}
                   value={contextWindow}
                   onChange={(e) =>
-                    setContextWindow(parseInt(e.target.value) || 50000)
+                    setContextWindow(parseInt(e.target.value) || 20)
                   }
                   className="h-9 text-sm"
                 />

--- a/web-ui/src/app/(auth)/bots/new/page.tsx
+++ b/web-ui/src/app/(auth)/bots/new/page.tsx
@@ -60,9 +60,9 @@ export default function NewBotPage() {
   const [githubRepo, setGithubRepo] = useState("");
   const [provider, setProvider] = useState<"claude" | "codex">("claude");
   const [model, setModel] = useState("claude-opus-4-5");
-  const [maxTurns, setMaxTurns] = useState(10);
+  const [maxTurns, setMaxTurns] = useState(5);
   const [fullAgent, setFullAgent] = useState(false);
-  const [contextWindow, setContextWindow] = useState(50000);
+  const [contextWindow, setContextWindow] = useState(20);
   const [autoExtract, setAutoExtract] = useState(true);
   const [enabledTools, setEnabledTools] = useState<string[]>([]);
   const [selectedDangerousTools, setSelectedDangerousTools] = useState<
@@ -359,21 +359,21 @@ export default function NewBotPage() {
                   min={1}
                   max={100}
                   value={maxTurns}
-                  onChange={(e) => setMaxTurns(parseInt(e.target.value) || 10)}
+                  onChange={(e) => setMaxTurns(parseInt(e.target.value) || 5)}
                   className="h-9 text-sm"
                 />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="context-window" className="text-xs">
-                  컨텍스트 윈도우
+                  컨텍스트 윈도우 (최근 메시지 수)
                 </Label>
                 <Input
                   id="context-window"
                   type="number"
-                  min={1000}
+                  min={1}
                   value={contextWindow}
                   onChange={(e) =>
-                    setContextWindow(parseInt(e.target.value) || 50000)
+                    setContextWindow(parseInt(e.target.value) || 20)
                   }
                   className="h-9 text-sm"
                 />

--- a/web-ui/src/app/(auth)/bots/page.tsx
+++ b/web-ui/src/app/(auth)/bots/page.tsx
@@ -34,10 +34,19 @@ import { buttonVariants } from "@/components/ui/button";
 interface BotData {
   id: string;
   name: string;
+  platform?: string;
   isActive: boolean;
   channels: string[];
+  security?: { allowed_channels?: string[] };
   claude: { provider?: string; model?: string };
   createdAt: string;
+}
+
+function getChannelCount(bot: BotData): number {
+  if (bot.channels?.length > 0) return bot.channels.length;
+  if ((bot.security?.allowed_channels?.length ?? 0) > 0)
+    return bot.security!.allowed_channels!.length;
+  return 0;
 }
 
 export default function BotsPage() {
@@ -173,10 +182,7 @@ export default function BotsPage() {
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-muted-foreground">
-                        {Array.isArray(bot.channels)
-                          ? bot.channels.length
-                          : 0}
-                        개
+                        {getChannelCount(bot)}개
                       </span>
                     </TableCell>
                     <TableCell className="text-right">

--- a/web-ui/src/app/api/airflow/dags/route.ts
+++ b/web-ui/src/app/api/airflow/dags/route.ts
@@ -16,7 +16,31 @@ export async function GET() {
       );
     }
     const data = await res.json();
-    return Response.json(data);
+
+    // Enrich each DAG with its latest run state.
+    // Airflow v2 /dags does not include last_run_state, which the frontend
+    // needs to compute running/failed/success counts in computeDagSummary().
+    const enrichedDags = await Promise.all(
+      (data.dags ?? []).map(async (dag: Record<string, unknown>) => {
+        try {
+          const runRes = await airflowFetch(
+            `/dags/${dag.dag_id}/dagRuns?limit=1&order_by=-start_date`
+          );
+          if (!runRes.ok) return { ...dag, last_run: null, last_run_state: null };
+          const runData = await runRes.json();
+          const lastRun = runData.dag_runs?.[0];
+          return {
+            ...dag,
+            last_run: lastRun?.start_date ?? null,
+            last_run_state: lastRun?.state ?? null,
+          };
+        } catch {
+          return { ...dag, last_run: null, last_run_state: null };
+        }
+      })
+    );
+
+    return Response.json({ ...data, dags: enrichedDags });
   } catch (error) {
     console.error("GET /api/airflow/dags error:", error);
     return Response.json({ error: "Failed to reach Airflow" }, { status: 503 });

--- a/web-ui/src/lib/airflow.ts
+++ b/web-ui/src/lib/airflow.ts
@@ -1,7 +1,12 @@
 const AIRFLOW_API_URL =
   process.env.AIRFLOW_API_URL || "http://airflow:8080/api/v2";
 
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
 async function getAirflowToken(): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt) {
+    return cachedToken.token;
+  }
   const baseUrl = AIRFLOW_API_URL.replace("/api/v2", "");
   const res = await fetch(`${baseUrl}/auth/token`, {
     method: "POST",
@@ -14,6 +19,7 @@ async function getAirflowToken(): Promise<string> {
   });
   if (!res.ok) throw new Error(`Airflow auth failed: ${res.status}`);
   const data = await res.json();
+  cachedToken = { token: data.access_token, expiresAt: Date.now() + 5 * 60 * 1000 };
   return data.access_token;
 }
 


### PR DESCRIPTION
## Summary
- **#34**: Discord 봇 채널 카운트 0 표시 수정 — 플랫폼 인식 `getChannelCount` 헬퍼 추가
- **#36**: 봇 max_turns 기본값 10→5, context_window 단위 불일치(토큰↔메시지) 수정
- **#39**: Airflow 대시보드 실패 DAG 카운트 미표시 — dagRuns enrichment 추가

## Test plan
- [ ] Go config tests pass (`go test ./internal/config/...`)
- [ ] New bot creation shows max_turns=5, context_window=20 defaults
- [ ] Editing existing bot preserves stored values
- [ ] Discord bot channel count reflects security.allowed_channels
- [ ] Airflow dashboard shows running/failed/success DAG counts
- [ ] Context window label shows "(최근 메시지 수)"

Closes #34, #36, #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)