### PR TITLE
feat: v0.4.0 — multi-platform auth, tool sync, credential probe

### DIFF
--- a/go/cmd/worker/main.go
+++ b/go/cmd/worker/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/baekenough/customclaw/internal/analysis"
 	"github.com/baekenough/customclaw/internal/config"
+	"github.com/baekenough/customclaw/internal/credprobe"
 	"github.com/baekenough/customclaw/internal/llm"
 	"github.com/baekenough/customclaw/internal/memory"
 	"github.com/baekenough/customclaw/internal/platform"
@@ -175,6 +176,10 @@ func run() error {
 			slog.Info("message processed", "bot", msg.BotID, "response_len", len(resp))
 		},
 	)
+
+	// Credential probe — periodically checks LLM provider credentials and
+	// stores results in the credential_status table. Fixes issue #32.
+	credprobe.Start(ctx, store.Pool())
 
 	// Analysis consumer — processes GitHub issue/PR analysis requests.
 	if err := rediswrapper.EnsureStreamGroup(ctx, rdb, analysis.AnalysisStream, analysis.AnalysisGroup); err != nil {

--- a/go/internal/credprobe/probe.go
+++ b/go/internal/credprobe/probe.go
@@ -1,0 +1,424 @@
+// Package credprobe periodically checks LLM provider credentials and stores
+// results in the credential_status PostgreSQL table. It sends Slack alerts on
+// ok→error transitions.
+package credprobe
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	defaultAlertChannel  = "C0AMBNY135Z"
+	defaultClaudeCLI     = "claude"
+	defaultContainerHome = "/home/appuser"
+	claudeTimeout        = 30 * time.Second
+	httpTimeout          = 10 * time.Second
+	probeInterval        = 30 * time.Minute
+)
+
+// stateTracker guards the previous-status map used for alert deduplication.
+var stateTracker = struct {
+	mu     sync.Mutex
+	states map[string]string
+}{
+	states: make(map[string]string),
+}
+
+// checkResult holds the outcome of a single provider check.
+type checkResult struct {
+	status string // "ok", "error", or "unconfigured"
+	errMsg string // non-empty only when status == "error"
+}
+
+// ---------------------------------------------------------------------------
+// Provider checks
+// ---------------------------------------------------------------------------
+
+// checkClaude runs the Claude CLI as a subprocess and inspects its JSON output.
+// Returns ("ok", "") on success, ("error", msg) on any failure.
+func checkClaude(ctx context.Context) checkResult {
+	cliPath := os.Getenv("CLAUDE_CLI_PATH")
+	if cliPath == "" {
+		cliPath = defaultClaudeCLI
+	}
+	homeDir := os.Getenv("CONTAINER_HOME")
+	if homeDir == "" {
+		homeDir = defaultContainerHome
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, claudeTimeout)
+	defer cancel()
+
+	args := []string{
+		"-p", ".",
+		"--model", "haiku",
+		"--max-turns", "1",
+		"--output-format", "json",
+	}
+	cmd := exec.CommandContext(execCtx, cliPath, args...)
+
+	// Inherit host environment and override HOME for container credential resolution.
+	env := os.Environ()
+	env = appendOrReplace(env, "HOME="+homeDir)
+	cmd.Env = env
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	output := strings.TrimSpace(stdout.String())
+	if output == "" {
+		output = strings.TrimSpace(stderr.String())
+	}
+
+	if runErr != nil {
+		// FileNotFoundError equivalent: exec.ErrNotFound or "executable file not found"
+		if strings.Contains(runErr.Error(), "executable file not found") ||
+			strings.Contains(runErr.Error(), "no such file") {
+			return checkResult{"error", fmt.Sprintf("Claude CLI not found at path: %s", cliPath)}
+		}
+		// Context deadline exceeded maps to timeout.
+		if execCtx.Err() == context.DeadlineExceeded {
+			return checkResult{"error", "Claude CLI timed out after 30 seconds"}
+		}
+		if output != "" {
+			return checkResult{"error", output}
+		}
+		return checkResult{"error", runErr.Error()}
+	}
+
+	if output == "" {
+		return checkResult{"ok", ""}
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(output), &data); err != nil {
+		// Non-JSON output with zero exit — treat as success.
+		return checkResult{"ok", ""}
+	}
+
+	isError, _ := data["is_error"].(bool)
+	if !isError {
+		return checkResult{"ok", ""}
+	}
+
+	// is_error: true — inspect for authentication failures.
+	raw, _ := json.Marshal(data)
+	rawStr := string(raw)
+	if strings.Contains(rawStr, "authentication_error") || strings.Contains(rawStr, "expired") {
+		errVal := data["error"]
+		switch v := errVal.(type) {
+		case map[string]any:
+			if msg, ok := v["message"].(string); ok {
+				return checkResult{"error", msg}
+			}
+		case string:
+			return checkResult{"error", v}
+		}
+		return checkResult{"error", rawStr}
+	}
+
+	if errVal, ok := data["error"].(string); ok && errVal != "" {
+		return checkResult{"error", errVal}
+	}
+	return checkResult{"error", rawStr}
+}
+
+// checkOpenAI validates the OpenAI API key via a lightweight GET to /v1/models.
+// Returns ("unconfigured", "") when OPENAI_API_KEY is absent.
+func checkOpenAI(ctx context.Context) checkResult {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		return checkResult{"unconfigured", ""}
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, httpTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, "https://api.openai.com/v1/models", nil)
+	if err != nil {
+		return checkResult{"error", err.Error()}
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if reqCtx.Err() == context.DeadlineExceeded {
+			return checkResult{"error", "OpenAI API timed out after 10 seconds"}
+		}
+		return checkResult{"error", err.Error()}
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return checkResult{"ok", ""}
+	case http.StatusUnauthorized:
+		msg := extractErrorMessage(resp.Body)
+		if msg == "" {
+			msg = "invalid or expired API key"
+		}
+		return checkResult{"error", msg}
+	default:
+		body := readBodyTruncated(resp.Body, 200)
+		return checkResult{"error", fmt.Sprintf("unexpected status %d: %s", resp.StatusCode, body)}
+	}
+}
+
+// checkGemini validates the Gemini API key via a GET to /v1beta/models.
+// Returns ("unconfigured", "") when GEMINI_API_KEY is absent.
+func checkGemini(ctx context.Context) checkResult {
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		return checkResult{"unconfigured", ""}
+	}
+
+	url := "https://generativelanguage.googleapis.com/v1beta/models?key=" + apiKey
+
+	reqCtx, cancel := context.WithTimeout(ctx, httpTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return checkResult{"error", err.Error()}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if reqCtx.Err() == context.DeadlineExceeded {
+			return checkResult{"error", "Gemini API timed out after 10 seconds"}
+		}
+		return checkResult{"error", err.Error()}
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return checkResult{"ok", ""}
+	case http.StatusBadRequest, http.StatusForbidden:
+		msg := extractErrorMessage(resp.Body)
+		if msg == "" {
+			msg = fmt.Sprintf("API returned %d", resp.StatusCode)
+		}
+		return checkResult{"error", msg}
+	default:
+		body := readBodyTruncated(resp.Body, 200)
+		return checkResult{"error", fmt.Sprintf("unexpected status %d: %s", resp.StatusCode, body)}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Database storage
+// ---------------------------------------------------------------------------
+
+// saveStatus upserts a provider's credential status into the credential_status table.
+func saveStatus(ctx context.Context, pool *pgxpool.Pool, provider, status, errMsg string) {
+	const q = `
+		INSERT INTO credential_status (provider, status, error, checked_at)
+		VALUES ($1, $2, $3, NOW())
+		ON CONFLICT (provider) DO UPDATE
+			SET status     = EXCLUDED.status,
+			    error      = EXCLUDED.error,
+			    checked_at = EXCLUDED.checked_at`
+
+	var errArg *string
+	if errMsg != "" {
+		errArg = &errMsg
+	}
+
+	if _, err := pool.Exec(ctx, q, provider, status, errArg); err != nil {
+		slog.Error("credential probe: failed to save status",
+			"provider", provider,
+			"status", status,
+			"error", err,
+		)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Slack alerting
+// ---------------------------------------------------------------------------
+
+// maybeAlert sends a Slack alert when a provider transitions into an error state.
+// It fires on the first "error" result (no prior state) or on a non-error→error transition.
+func maybeAlert(provider, status, errMsg string) {
+	stateTracker.mu.Lock()
+	previous := stateTracker.states[provider]
+	stateTracker.states[provider] = status
+	stateTracker.mu.Unlock()
+
+	if status == "error" && previous != "error" {
+		sendSlackAlert(provider, errMsg)
+	}
+}
+
+// sendSlackAlert posts an alert message to the configured Slack channel.
+func sendSlackAlert(provider, errMsg string) {
+	token := os.Getenv("CUSTOMCLAW_SLACK_BOT_TOKEN")
+	if token == "" {
+		slog.Warn("credential probe: CUSTOMCLAW_SLACK_BOT_TOKEN not set; skipping Slack alert")
+		return
+	}
+	channel := os.Getenv("CREDENTIAL_ALERT_CHANNEL")
+	if channel == "" {
+		channel = defaultAlertChannel
+	}
+
+	text := fmt.Sprintf(
+		"\u26a0\ufe0f *LLM Credential Alert*\n%s 인증 실패: %s\n서버에서 credential 갱신이 필요합니다.",
+		provider, errMsg,
+	)
+
+	payload, err := json.Marshal(map[string]string{
+		"channel": channel,
+		"text":    text,
+	})
+	if err != nil {
+		slog.Error("credential probe: failed to marshal Slack payload", "error", err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.postMessage",
+		bytes.NewReader(payload))
+	if err != nil {
+		slog.Error("credential probe: failed to create Slack request", "error", err)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Error("credential probe: Slack API request failed", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		slog.Error("credential probe: failed to parse Slack response", "error", err)
+		return
+	}
+	if ok, _ := result["ok"].(bool); !ok {
+		slackErr, _ := result["error"].(string)
+		slog.Error("credential probe: Slack alert failed", "slack_error", slackErr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Main probe loop
+// ---------------------------------------------------------------------------
+
+type provider struct {
+	name  string
+	check func(ctx context.Context) checkResult
+}
+
+var providers = []provider{
+	{"claude", checkClaude},
+	{"openai", checkOpenAI},
+	{"gemini", checkGemini},
+}
+
+// runProbe executes one full round of credential checks across all providers.
+func runProbe(ctx context.Context, pool *pgxpool.Pool) {
+	for _, p := range providers {
+		result := p.check(ctx)
+		if result.errMsg != "" {
+			slog.Info("credential probe",
+				"provider", p.name,
+				"status", result.status,
+				"error", result.errMsg,
+			)
+		} else {
+			slog.Info("credential probe",
+				"provider", p.name,
+				"status", result.status,
+			)
+		}
+		saveStatus(ctx, pool, p.name, result.status, result.errMsg)
+		maybeAlert(p.name, result.status, result.errMsg)
+	}
+}
+
+// Start launches the credential probe as a background goroutine. It runs one
+// immediate check then repeats every 30 minutes until ctx is cancelled.
+//
+// The provided pool must remain valid for the lifetime of the background loop.
+func Start(ctx context.Context, pool *pgxpool.Pool) {
+	go func() {
+		slog.Info("credential probe starting", "interval", "30m")
+		ticker := time.NewTicker(probeInterval)
+		defer ticker.Stop()
+
+		runProbe(ctx, pool) // immediate first run
+		for {
+			select {
+			case <-ctx.Done():
+				slog.Info("credential probe stopping")
+				return
+			case <-ticker.C:
+				runProbe(ctx, pool)
+			}
+		}
+	}()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// appendOrReplace adds key=value to env, replacing an existing entry for key.
+func appendOrReplace(env []string, kv string) []string {
+	key := kv[:strings.IndexByte(kv, '=')]
+	for i, e := range env {
+		if strings.HasPrefix(e, key+"=") {
+			env[i] = kv
+			return env
+		}
+	}
+	return append(env, kv)
+}
+
+// extractErrorMessage reads a JSON response body and returns the error message
+// at .error.message, falling back to the raw body text on failure.
+func extractErrorMessage(r io.Reader) string {
+	body, err := io.ReadAll(io.LimitReader(r, 4096))
+	if err != nil || len(body) == 0 {
+		return ""
+	}
+	var data map[string]any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return strings.TrimSpace(string(body))
+	}
+	if errObj, ok := data["error"].(map[string]any); ok {
+		if msg, ok := errObj["message"].(string); ok {
+			return msg
+		}
+	}
+	return strings.TrimSpace(string(body))
+}
+
+// readBodyTruncated reads up to maxBytes from r and returns it as a string.
+func readBodyTruncated(r io.Reader, maxBytes int64) string {
+	b, _ := io.ReadAll(io.LimitReader(r, maxBytes))
+	return strings.TrimSpace(string(b))
+}

--- a/go/internal/credprobe/probe_test.go
+++ b/go/internal/credprobe/probe_test.go
@@ -1,0 +1,51 @@
+package credprobe
+
+import (
+	"context"
+	"testing"
+)
+
+// TestCheckOpenAI_Unconfigured verifies that an absent OPENAI_API_KEY yields
+// "unconfigured" without making any network calls.
+func TestCheckOpenAI_Unconfigured(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+
+	result := checkOpenAI(context.Background())
+
+	if result.status != "unconfigured" {
+		t.Errorf("expected status %q, got %q", "unconfigured", result.status)
+	}
+	if result.errMsg != "" {
+		t.Errorf("expected empty errMsg, got %q", result.errMsg)
+	}
+}
+
+// TestCheckGemini_Unconfigured verifies that an absent GEMINI_API_KEY yields
+// "unconfigured" without making any network calls.
+func TestCheckGemini_Unconfigured(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "")
+
+	result := checkGemini(context.Background())
+
+	if result.status != "unconfigured" {
+		t.Errorf("expected status %q, got %q", "unconfigured", result.status)
+	}
+	if result.errMsg != "" {
+		t.Errorf("expected empty errMsg, got %q", result.errMsg)
+	}
+}
+
+// TestCheckClaude_NotFound verifies that a nonexistent CLI path returns "error"
+// with an informative message, rather than panicking or hanging.
+func TestCheckClaude_NotFound(t *testing.T) {
+	t.Setenv("CLAUDE_CLI_PATH", "/nonexistent/path/to/claude-cli-that-does-not-exist")
+
+	result := checkClaude(context.Background())
+
+	if result.status != "error" {
+		t.Errorf("expected status %q, got %q", "error", result.status)
+	}
+	if result.errMsg == "" {
+		t.Error("expected non-empty errMsg when CLI path does not exist")
+	}
+}

--- a/go/internal/memory/store.go
+++ b/go/internal/memory/store.go
@@ -105,6 +105,13 @@ func (s *MessageStore) Close() {
 	}
 }
 
+// Pool returns the underlying pgxpool.Pool so callers that need direct pool
+// access (e.g. credprobe) do not have to maintain a separate connection pool.
+// Returns nil when the store is running in no-op / in-memory mode.
+func (s *MessageStore) Pool() *pgxpool.Pool {
+	return s.pool
+}
+
 // ---------------------------------------------------------------------------
 // Core persistence
 // ---------------------------------------------------------------------------

--- a/web-ui/src/app/(auth)/bots/[id]/page.tsx
+++ b/web-ui/src/app/(auth)/bots/[id]/page.tsx
@@ -33,25 +33,16 @@ import {
 import { ChevronLeft, Eye, EyeOff, X, Plus, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
-
-const AVAILABLE_TOOLS = [
-  "bash",
-  "read_file",
-  "write_file",
-  "search_code",
-  "git",
-  "github",
-  "web_search",
-  "jira",
-];
-
-const DANGEROUS_TOOLS = ["bash", "write_file", "git"];
+import { AVAILABLE_TOOLS, DANGEROUS_TOOLS } from "@/lib/bot-tools";
 
 interface BotRaw {
   id: string;
   name: string;
+  platform?: string;
   slackAppToken: string;
   slackBotToken: string;
+  discord?: { token?: string; guild_id?: string };
+  mattermost?: { url?: string; token?: string; port?: number };
   channels: string[];
   isActive: boolean;
   persona: { display_name?: string; description?: string; personality?: string };
@@ -85,8 +76,14 @@ export default function BotDetailPage({
 
   // Form state
   const [name, setName] = useState("");
+  const [platform, setPlatform] = useState<"slack" | "discord" | "mattermost">("slack");
   const [slackAppToken, setSlackAppToken] = useState("");
   const [slackBotToken, setSlackBotToken] = useState("");
+  const [discordToken, setDiscordToken] = useState("");
+  const [discordGuildId, setDiscordGuildId] = useState("");
+  const [mattermostUrl, setMattermostUrl] = useState("");
+  const [mattermostToken, setMattermostToken] = useState("");
+  const [mattermostPort, setMattermostPort] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [description, setDescription] = useState("");
   const [personality, setPersonality] = useState("");
@@ -110,8 +107,14 @@ export default function BotDetailPage({
       .then((data: BotRaw) => {
         setBot(data);
         setName(data.name);
+        setPlatform((data.platform as "slack" | "discord" | "mattermost") ?? "slack");
         setSlackAppToken(data.slackAppToken);
         setSlackBotToken(data.slackBotToken);
+        setDiscordToken(data.discord?.token ?? "");
+        setDiscordGuildId(data.discord?.guild_id ?? "");
+        setMattermostUrl(data.mattermost?.url ?? "");
+        setMattermostToken(data.mattermost?.token ?? "");
+        setMattermostPort(data.mattermost?.port ? String(data.mattermost.port) : "");
         setDisplayName(data.persona?.display_name ?? "");
         setDescription(data.persona?.description ?? "");
         setPersonality(data.persona?.personality ?? "");
@@ -160,8 +163,12 @@ export default function BotDetailPage({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name,
-          slackAppToken,
-          slackBotToken,
+          platform,
+          ...(platform === "discord"
+            ? { discord: { token: discordToken, guild_id: discordGuildId }, slackAppToken: "", slackBotToken: "" }
+            : platform === "mattermost"
+            ? { mattermost: { url: mattermostUrl, token: mattermostToken, port: mattermostPort ? parseInt(mattermostPort) : 8065 }, slackAppToken: "", slackBotToken: "" }
+            : { slackAppToken, slackBotToken }),
           channels: allowedChannels,
           isActive,
           persona: { display_name: displayName, description, personality },
@@ -258,6 +265,22 @@ export default function BotDetailPage({
             <CardTitle className="text-sm">기본 정보</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label className="text-xs">플랫폼</Label>
+              <Select
+                value={platform}
+                onValueChange={(v) => setPlatform(v as "slack" | "discord" | "mattermost")}
+              >
+                <SelectTrigger className="h-9 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="slack">Slack</SelectItem>
+                  <SelectItem value="discord">Discord</SelectItem>
+                  <SelectItem value="mattermost">Mattermost</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label className="text-xs">봇 ID</Label>
@@ -292,65 +315,156 @@ export default function BotDetailPage({
           </CardContent>
         </Card>
 
-        {/* Slack 토큰 */}
-        <Card className="border-border/50">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm">Slack 토큰</CardTitle>
-            <CardDescription className="text-xs">
-              수정하려면 새 값을 입력하세요
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label className="text-xs">App Token</Label>
-              <div className="relative">
-                <Input
-                  type={showAppToken ? "text" : "password"}
-                  value={slackAppToken}
-                  onChange={(e) => setSlackAppToken(e.target.value)}
-                  placeholder={maskToken(bot?.slackAppToken ?? "")}
-                  className="h-9 text-sm font-mono pr-10"
-                />
-                <button
-                  type="button"
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  onClick={() => setShowAppToken(!showAppToken)}
-                  aria-label={showAppToken ? "토큰 숨기기" : "토큰 보기"}
-                >
-                  {showAppToken ? (
-                    <EyeOff className="h-3.5 w-3.5" />
-                  ) : (
-                    <Eye className="h-3.5 w-3.5" />
-                  )}
-                </button>
+        {/* 인증 */}
+        {platform === "slack" && (
+          <Card className="border-border/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm">Slack 토큰</CardTitle>
+              <CardDescription className="text-xs">
+                수정하려면 새 값을 입력하세요
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label className="text-xs">App Token</Label>
+                <div className="relative">
+                  <Input
+                    type={showAppToken ? "text" : "password"}
+                    value={slackAppToken}
+                    onChange={(e) => setSlackAppToken(e.target.value)}
+                    placeholder={maskToken(bot?.slackAppToken ?? "")}
+                    className="h-9 text-sm font-mono pr-10"
+                  />
+                  <button
+                    type="button"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    onClick={() => setShowAppToken(!showAppToken)}
+                    aria-label={showAppToken ? "토큰 숨기기" : "토큰 보기"}
+                  >
+                    {showAppToken ? (
+                      <EyeOff className="h-3.5 w-3.5" />
+                    ) : (
+                      <Eye className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                </div>
               </div>
-            </div>
-            <div className="space-y-2">
-              <Label className="text-xs">Bot Token</Label>
-              <div className="relative">
-                <Input
-                  type={showBotToken ? "text" : "password"}
-                  value={slackBotToken}
-                  onChange={(e) => setSlackBotToken(e.target.value)}
-                  placeholder={maskToken(bot?.slackBotToken ?? "")}
-                  className="h-9 text-sm font-mono pr-10"
-                />
-                <button
-                  type="button"
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  onClick={() => setShowBotToken(!showBotToken)}
-                  aria-label={showBotToken ? "토큰 숨기기" : "토큰 보기"}
-                >
-                  {showBotToken ? (
-                    <EyeOff className="h-3.5 w-3.5" />
-                  ) : (
-                    <Eye className="h-3.5 w-3.5" />
-                  )}
-                </button>
+              <div className="space-y-2">
+                <Label className="text-xs">Bot Token</Label>
+                <div className="relative">
+                  <Input
+                    type={showBotToken ? "text" : "password"}
+                    value={slackBotToken}
+                    onChange={(e) => setSlackBotToken(e.target.value)}
+                    placeholder={maskToken(bot?.slackBotToken ?? "")}
+                    className="h-9 text-sm font-mono pr-10"
+                  />
+                  <button
+                    type="button"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    onClick={() => setShowBotToken(!showBotToken)}
+                    aria-label={showBotToken ? "토큰 숨기기" : "토큰 보기"}
+                  >
+                    {showBotToken ? (
+                      <EyeOff className="h-3.5 w-3.5" />
+                    ) : (
+                      <Eye className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                </div>
               </div>
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        )}
+
+        {platform === "discord" && (
+          <Card className="border-border/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm">Discord 인증</CardTitle>
+              <CardDescription className="text-xs">
+                수정하려면 새 값을 입력하세요
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="edit-discord-token" className="text-xs">
+                  Bot Token <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  id="edit-discord-token"
+                  type="password"
+                  value={discordToken}
+                  onChange={(e) => setDiscordToken(e.target.value)}
+                  placeholder={bot?.discord?.token ? "••••••••" : "MTxxxxxxxxxxxxxxxxxxxxxxxx...."}
+                  className="h-9 text-sm font-mono"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-discord-guild-id" className="text-xs">
+                  Guild ID
+                </Label>
+                <Input
+                  id="edit-discord-guild-id"
+                  value={discordGuildId}
+                  onChange={(e) => setDiscordGuildId(e.target.value)}
+                  placeholder="123456789012345678"
+                  className="h-9 text-sm font-mono"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {platform === "mattermost" && (
+          <Card className="border-border/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm">Mattermost 인증</CardTitle>
+              <CardDescription className="text-xs">
+                수정하려면 새 값을 입력하세요
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="edit-mattermost-url" className="text-xs">
+                  서버 URL <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  id="edit-mattermost-url"
+                  value={mattermostUrl}
+                  onChange={(e) => setMattermostUrl(e.target.value)}
+                  placeholder="https://mattermost.example.com"
+                  className="h-9 text-sm font-mono"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-mattermost-token" className="text-xs">
+                  Bot Token <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  id="edit-mattermost-token"
+                  type="password"
+                  value={mattermostToken}
+                  onChange={(e) => setMattermostToken(e.target.value)}
+                  placeholder={bot?.mattermost?.token ? "••••••••" : "xxxxxxxxxxxxxxxxxxxxxxxxxx"}
+                  className="h-9 text-sm font-mono"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-mattermost-port" className="text-xs">
+                  포트 (기본값: 8065)
+                </Label>
+                <Input
+                  id="edit-mattermost-port"
+                  type="number"
+                  value={mattermostPort}
+                  onChange={(e) => setMattermostPort(e.target.value)}
+                  placeholder="8065"
+                  className="h-9 text-sm"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
         {/* 페르소나 */}
         <Card className="border-border/50">

--- a/web-ui/src/app/(auth)/bots/new/page.tsx
+++ b/web-ui/src/app/(auth)/bots/new/page.tsx
@@ -25,23 +25,7 @@ import { Separator } from "@/components/ui/separator";
 import { ChevronLeft, X, Plus } from "lucide-react";
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
-
-const AVAILABLE_TOOLS = [
-  "bash",
-  "read_file",
-  "write_file",
-  "search_code",
-  "git",
-  "github",
-  "web_search",
-  "jira",
-];
-
-const DANGEROUS_TOOLS = [
-  "bash",
-  "write_file",
-  "git",
-];
+import { AVAILABLE_TOOLS, DANGEROUS_TOOLS } from "@/lib/bot-tools";
 
 export default function NewBotPage() {
   const router = useRouter();
@@ -51,8 +35,14 @@ export default function NewBotPage() {
   // Form state
   const [id, setId] = useState("");
   const [name, setName] = useState("");
+  const [platform, setPlatform] = useState<"slack" | "discord" | "mattermost">("slack");
   const [slackAppToken, setSlackAppToken] = useState("");
   const [slackBotToken, setSlackBotToken] = useState("");
+  const [discordToken, setDiscordToken] = useState("");
+  const [discordGuildId, setDiscordGuildId] = useState("");
+  const [mattermostUrl, setMattermostUrl] = useState("");
+  const [mattermostToken, setMattermostToken] = useState("");
+  const [mattermostPort, setMattermostPort] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [description, setDescription] = useState("");
   const [personality, setPersonality] = useState("");
@@ -97,14 +87,21 @@ export default function NewBotPage() {
     setSubmitting(true);
 
     try {
+      const platformPayload =
+        platform === "discord"
+          ? { discord: { token: discordToken, guild_id: discordGuildId }, slackAppToken: "", slackBotToken: "" }
+          : platform === "mattermost"
+          ? { mattermost: { url: mattermostUrl, token: mattermostToken, port: mattermostPort ? parseInt(mattermostPort) : 8065 }, slackAppToken: "", slackBotToken: "" }
+          : { slackAppToken, slackBotToken };
+
       const res = await fetch("/api/bots", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           id,
           name,
-          slackAppToken,
-          slackBotToken,
+          platform,
+          ...platformPayload,
           channels: allowedChannels,
           persona: { display_name: displayName, description, personality },
           project: { repo_path: repoPath, github_repo: githubRepo },
@@ -142,7 +139,7 @@ export default function NewBotPage() {
         <div>
           <h1 className="text-2xl font-bold text-foreground">새 봇 만들기</h1>
           <p className="text-sm text-muted-foreground mt-0.5">
-            새로운 Slack 봇을 등록합니다
+            새로운 봇을 등록합니다
           </p>
         </div>
       </div>
@@ -160,6 +157,24 @@ export default function NewBotPage() {
             <CardTitle className="text-sm">기본 정보</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="platform" className="text-xs">
+                플랫폼 <span className="text-destructive">*</span>
+              </Label>
+              <Select
+                value={platform}
+                onValueChange={(v) => setPlatform(v as "slack" | "discord" | "mattermost")}
+              >
+                <SelectTrigger id="platform" className="h-9 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="slack">Slack</SelectItem>
+                  <SelectItem value="discord">Discord</SelectItem>
+                  <SelectItem value="mattermost">Mattermost</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="bot-id" className="text-xs">
@@ -194,45 +209,139 @@ export default function NewBotPage() {
           </CardContent>
         </Card>
 
-        {/* Slack 토큰 */}
-        <Card className="border-border/50">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm">Slack 토큰</CardTitle>
-            <CardDescription className="text-xs">
-              Slack App 설정에서 발급받은 토큰
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="app-token" className="text-xs">
-                App Token <span className="text-destructive">*</span>
-              </Label>
-              <Input
-                id="app-token"
-                type="password"
-                value={slackAppToken}
-                onChange={(e) => setSlackAppToken(e.target.value)}
-                placeholder="xapp-..."
-                required
-                className="h-9 text-sm font-mono"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="bot-token" className="text-xs">
-                Bot Token <span className="text-destructive">*</span>
-              </Label>
-              <Input
-                id="bot-token"
-                type="password"
-                value={slackBotToken}
-                onChange={(e) => setSlackBotToken(e.target.value)}
-                placeholder="xoxb-..."
-                required
-                className="h-9 text-sm font-mono"
-              />
-            </div>
-          </CardContent>
-        </Card>
+        {/* 인증 */}
+        {platform === "slack" && (
+          <Card className="border-border/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm">Slack 토큰</CardTitle>
+              <CardDescription className="text-xs">
+                Slack App 설정에서 발급받은 토큰
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="app-token" className="text-xs">
+                  App Token <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  id="app-token"
+                  type="password"
+                  value={slackAppToken}
+                  onChange={(e) => setSlackAppToken(e.target.value)}
+                  placeholder="xapp-..."
+                  required
+                  className="h-9 text-sm font-mono"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="bot-token" className="text-xs">
+                  Bot Token <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  id="bot-token"
+                  type="password"
+                  value={slackBotToken}
+                  onChange={(e) => setSlackBotToken(e.target.value)}
+                  placeholder="xoxb-..."
+                  required
+                  className="h-9 text-sm font-mono"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {platform === "discord" && (
+          <Card className="border-border/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm">Discord 인증</CardTitle>
+              <CardDescription className="text-xs">
+                Discord Developer Portal에서 발급받은 봇 토큰
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="discord-token" className="text-xs">
+                  Bot Token <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  id="discord-token"
+                  type="password"
+                  value={discordToken}
+                  onChange={(e) => setDiscordToken(e.target.value)}
+                  placeholder="MTxxxxxxxxxxxxxxxxxxxxxxxx...."
+                  required
+                  className="h-9 text-sm font-mono"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="discord-guild-id" className="text-xs">
+                  Guild ID
+                </Label>
+                <Input
+                  id="discord-guild-id"
+                  value={discordGuildId}
+                  onChange={(e) => setDiscordGuildId(e.target.value)}
+                  placeholder="123456789012345678"
+                  className="h-9 text-sm font-mono"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {platform === "mattermost" && (
+          <Card className="border-border/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm">Mattermost 인증</CardTitle>
+              <CardDescription className="text-xs">
+                Mattermost 서버 연결 정보
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="mattermost-url" className="text-xs">
+                  서버 URL <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  id="mattermost-url"
+                  value={mattermostUrl}
+                  onChange={(e) => setMattermostUrl(e.target.value)}
+                  placeholder="https://mattermost.example.com"
+                  required
+                  className="h-9 text-sm font-mono"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="mattermost-token" className="text-xs">
+                  Bot Token <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  id="mattermost-token"
+                  type="password"
+                  value={mattermostToken}
+                  onChange={(e) => setMattermostToken(e.target.value)}
+                  placeholder="xxxxxxxxxxxxxxxxxxxxxxxxxx"
+                  required
+                  className="h-9 text-sm font-mono"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="mattermost-port" className="text-xs">
+                  포트 (기본값: 8065)
+                </Label>
+                <Input
+                  id="mattermost-port"
+                  type="number"
+                  value={mattermostPort}
+                  onChange={(e) => setMattermostPort(e.target.value)}
+                  placeholder="8065"
+                  className="h-9 text-sm"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
         {/* 페르소나 */}
         <Card className="border-border/50">

--- a/web-ui/src/app/(auth)/bots/page.tsx
+++ b/web-ui/src/app/(auth)/bots/page.tsx
@@ -91,7 +91,7 @@ export default function BotsPage() {
         <div>
           <h1 className="text-2xl font-bold text-foreground">봇 관리</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            등록된 Slack 봇 목록
+            등록된 봇 목록
           </p>
         </div>
         <Link
@@ -134,6 +134,7 @@ export default function BotsPage() {
               <TableHeader>
                 <TableRow className="border-border/50 hover:bg-transparent">
                   <TableHead className="text-xs">이름</TableHead>
+                  <TableHead className="text-xs">플랫폼</TableHead>
                   <TableHead className="text-xs">Provider</TableHead>
                   <TableHead className="text-xs">모델</TableHead>
                   <TableHead className="text-xs">상태</TableHead>
@@ -154,6 +155,26 @@ export default function BotsPage() {
                           {bot.id}
                         </p>
                       </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={
+                          bot.platform === "discord"
+                            ? "secondary"
+                            : bot.platform === "mattermost"
+                            ? "outline"
+                            : "default"
+                        }
+                        className={`text-xs capitalize ${
+                          bot.platform === "discord"
+                            ? "bg-violet-500/15 text-violet-400 border-0 hover:bg-violet-500/20"
+                            : bot.platform === "slack"
+                            ? "bg-emerald-500/15 text-emerald-400 border-0 hover:bg-emerald-500/20"
+                            : ""
+                        }`}
+                      >
+                        {bot.platform ?? "slack"}
+                      </Badge>
                     </TableCell>
                     <TableCell>
                       <Badge

--- a/web-ui/src/app/api/bots/[id]/route.ts
+++ b/web-ui/src/app/api/bots/[id]/route.ts
@@ -44,8 +44,11 @@ export async function PUT(
 
     const {
       name,
+      platform,
       slackAppToken,
       slackBotToken,
+      discord,
+      mattermost,
       channels,
       persona,
       project,
@@ -61,8 +64,11 @@ export async function PUT(
       where: { id },
       data: {
         ...(name !== undefined && { name }),
+        ...(platform !== undefined && { platform }),
         ...(slackAppToken !== undefined && { slackAppToken }),
         ...(slackBotToken !== undefined && { slackBotToken }),
+        ...(discord !== undefined && { discord }),
+        ...(mattermost !== undefined && { mattermost }),
         ...(channels !== undefined && { channels }),
         ...(persona !== undefined && { persona }),
         ...(project !== undefined && { project }),

--- a/web-ui/src/app/api/bots/route.ts
+++ b/web-ui/src/app/api/bots/route.ts
@@ -30,8 +30,11 @@ export async function POST(request: NextRequest) {
     const {
       id,
       name,
+      platform,
       slackAppToken,
       slackBotToken,
+      discord,
+      mattermost,
       channels,
       persona,
       project,
@@ -43,9 +46,26 @@ export async function POST(request: NextRequest) {
       isActive,
     } = body;
 
-    if (!id || !name || !slackAppToken || !slackBotToken) {
+    const resolvedPlatform = platform ?? "slack";
+
+    if (!id || !name) {
+      return Response.json({ error: "id and name are required" }, { status: 400 });
+    }
+    if (resolvedPlatform === "slack" && (!slackAppToken || !slackBotToken)) {
       return Response.json(
-        { error: "id, name, slackAppToken, slackBotToken are required" },
+        { error: "slackAppToken and slackBotToken are required for Slack bots" },
+        { status: 400 }
+      );
+    }
+    if (resolvedPlatform === "discord" && !discord?.token) {
+      return Response.json(
+        { error: "discord.token is required for Discord bots" },
+        { status: 400 }
+      );
+    }
+    if (resolvedPlatform === "mattermost" && (!mattermost?.url || !mattermost?.token)) {
+      return Response.json(
+        { error: "mattermost.url and mattermost.token are required for Mattermost bots" },
         { status: 400 }
       );
     }
@@ -54,8 +74,11 @@ export async function POST(request: NextRequest) {
       data: {
         id,
         name,
-        slackAppToken,
-        slackBotToken,
+        platform: resolvedPlatform,
+        slackAppToken: slackAppToken ?? "",
+        slackBotToken: slackBotToken ?? "",
+        ...(discord !== undefined && { discord }),
+        ...(mattermost !== undefined && { mattermost }),
         channels: channels ?? [],
         persona: persona ?? {},
         project: project ?? {},

--- a/web-ui/src/lib/bot-tools.ts
+++ b/web-ui/src/lib/bot-tools.ts
@@ -1,0 +1,22 @@
+export const AVAILABLE_TOOLS = [
+  "search_code",
+  "create_issue",
+  "query_issues",
+  "get_dag_status",
+  "list_dag_runs",
+  "list_dags",
+  "trigger_dag",
+  "create_bot",
+  "list_bots",
+  "update_bot",
+  "delete_bot",
+  "restart_runtime",
+];
+
+export const DANGEROUS_TOOLS = [
+  "create_bot",
+  "update_bot",
+  "delete_bot",
+  "restart_runtime",
+  "trigger_dag",
+];


### PR DESCRIPTION
## Summary
- **#35**: 봇 생성/편집 시 플랫폼별(Slack/Discord/Mattermost) 인증 필드 분리 및 조건부 검증
- **#38**: 프론트엔드 도구 목록을 실제 Go worker registry(12개)와 동기화, 공유 상수 파일 추출
- **#32**: Python credential_probe를 Go로 포팅 — 30분 주기 LLM 프로바이더 상태 체크 + DB 저장 + Slack 알림

## Test plan
- [ ] Go credprobe tests pass (`go test ./internal/credprobe/...`)
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] Slack 봇 생성: slackAppToken/slackBotToken 필수 확인
- [ ] Discord 봇 생성: discord.token 필수, Slack 토큰 비필수 확인
- [ ] Mattermost 봇 생성: url + token 필수 확인
- [ ] 봇 목록 페이지에서 플랫폼 뱃지 표시 확인
- [ ] 도구 목록에 12개 실제 도구만 표시 확인
- [ ] Go worker 시작 후 credential_status 테이블 업데이트 확인

Closes #35, #38, #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)