### PR TITLE
fix: v0.4.1 — UX polish, lint fix, CI gate rule

### DIFF
--- a/go/internal/credprobe/probe.go
+++ b/go/internal/credprobe/probe.go
@@ -163,7 +163,7 @@ func checkOpenAI(ctx context.Context) checkResult {
 		}
 		return checkResult{"error", err.Error()}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -205,7 +205,7 @@ func checkGemini(ctx context.Context) checkResult {
 		}
 		return checkResult{"error", err.Error()}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -310,7 +310,7 @@ func sendSlackAlert(provider, errMsg string) {
 		slog.Error("credential probe: Slack API request failed", "error", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var result map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {

--- a/web-ui/src/app/(auth)/bots/[id]/page.tsx
+++ b/web-ui/src/app/(auth)/bots/[id]/page.tsx
@@ -30,7 +30,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ChevronLeft, Eye, EyeOff, X, Plus, Trash2 } from "lucide-react";
+import { ChevronLeft, Eye, EyeOff, X, Plus, Trash2, HelpCircle } from "lucide-react";
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { AVAILABLE_TOOLS, DANGEROUS_TOOLS } from "@/lib/bot-tools";
@@ -590,6 +590,9 @@ export default function BotDetailPage({
                   className="h-4 w-4 rounded border-border accent-primary"
                 />
                 <span className="text-sm">Full Agent 모드</span>
+                <span title="활성화 시 봇이 도구(tool)를 사용하여 코드 실행, 파일 검색 등 확장된 작업을 수행할 수 있습니다.">
+                  <HelpCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                </span>
               </label>
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
@@ -599,6 +602,9 @@ export default function BotDetailPage({
                   className="h-4 w-4 rounded border-border accent-primary"
                 />
                 <span className="text-sm">메모리 자동 추출</span>
+                <span title="대화에서 중요한 정보를 자동으로 추출하여 장기 기억으로 저장합니다.">
+                  <HelpCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                </span>
               </label>
             </div>
           </CardContent>

--- a/web-ui/src/app/(auth)/bots/new/page.tsx
+++ b/web-ui/src/app/(auth)/bots/new/page.tsx
@@ -22,7 +22,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { ChevronLeft, X, Plus } from "lucide-react";
+import { ChevronLeft, X, Plus, HelpCircle } from "lucide-react";
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { AVAILABLE_TOOLS, DANGEROUS_TOOLS } from "@/lib/bot-tools";
@@ -497,6 +497,9 @@ export default function NewBotPage() {
                   className="h-4 w-4 rounded border-border accent-primary"
                 />
                 <span className="text-sm">Full Agent 모드</span>
+                <span title="활성화 시 봇이 도구(tool)를 사용하여 코드 실행, 파일 검색 등 확장된 작업을 수행할 수 있습니다.">
+                  <HelpCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                </span>
               </label>
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
@@ -506,6 +509,9 @@ export default function NewBotPage() {
                   className="h-4 w-4 rounded border-border accent-primary"
                 />
                 <span className="text-sm">메모리 자동 추출</span>
+                <span title="대화에서 중요한 정보를 자동으로 추출하여 장기 기억으로 저장합니다.">
+                  <HelpCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                </span>
               </label>
             </div>
           </CardContent>

--- a/web-ui/src/app/(auth)/page.tsx
+++ b/web-ui/src/app/(auth)/page.tsx
@@ -874,22 +874,26 @@ export default function DashboardPage() {
                     <YAxis fontSize={12} tickLine={false} axisLine={false} />
                     <Tooltip content={<CustomTooltip />} />
                     <Area
-                      type="monotone"
+                      type="linear"
                       dataKey="messages"
                       name="메시지"
                       stroke={CHART_COLORS.primary}
                       fillOpacity={1}
                       fill="url(#colorMessages)"
                       strokeWidth={2}
+                      dot={{ r: 3, fill: CHART_COLORS.primary, strokeWidth: 0 }}
+                      activeDot={{ r: 5, fill: CHART_COLORS.primary, strokeWidth: 0 }}
                     />
                     <Area
-                      type="monotone"
+                      type="linear"
                       dataKey="botMessages"
                       name="봇 응답"
                       stroke={CHART_COLORS.secondary}
                       fillOpacity={1}
                       fill="url(#colorBotMessages)"
                       strokeWidth={2}
+                      dot={{ r: 3, fill: CHART_COLORS.secondary, strokeWidth: 0 }}
+                      activeDot={{ r: 5, fill: CHART_COLORS.secondary, strokeWidth: 0 }}
                     />
                   </AreaChart>
                 </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- **#33**: 대시보드 일별 활동 추이 차트 가독성 개선
- **#37**: Full Agent 모드/메모리 자동 추출 토글에 설명 툴팁 추가
- **lint fix**: credprobe `resp.Body.Close()` errcheck 3건 수정 (v0.4.0 후속)
- **R020 업데이트**: CI 게이트 규칙 추가 — 모든 CI 체크 통과 필수

## Test plan
- [ ] `go test ./internal/credprobe/...` 통과
- [ ] `npx tsc --noEmit` 에러 없음
- [ ] golangci-lint errcheck 통과
- [ ] 대시보드 차트 가독성 시각 확인
- [ ] 봇 설정 툴팁 hover 동작 확인

Closes #33, #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)