### PR TITLE
fix: P1 bug fixes and platform monitoring (v0.5.1)

### DIFF
--- a/dags/shared/credential_keepalive.py
+++ b/dags/shared/credential_keepalive.py
@@ -1,12 +1,18 @@
 """Credential Keepalive DAG.
 
 Periodically refreshes LLM CLI OAuth tokens to prevent expiry-driven outages.
-Claude OAuth tokens expire after ~8 hours; this DAG runs every 4 hours to keep
+Claude OAuth tokens expire after ~8 hours; this DAG runs every hour to keep
 them fresh and restarts the go-worker if it was previously stuck in an error
 state due to a stale token.
 
+Codex CLI uses ChatGPT OAuth which cannot be auto-refreshed.  When a 401 /
+auth failure is detected the DAG initiates a device-auth flow inside the
+go-worker container, captures the device code + URL, and sends them to Slack
+so the operator can authenticate from any device within 5 minutes.
+
 Graph:
     check_status ─► refresh_claude ─► verify_and_alert
+    check_codex  ─► recover_codex
 """
 
 from __future__ import annotations
@@ -15,6 +21,7 @@ import json
 import logging
 import os
 import subprocess
+import time
 from datetime import datetime, timedelta
 
 import requests
@@ -52,6 +59,9 @@ DEFAULT_ALERT_CHANNEL = "C0AMBNY135Z"
 DOCKER_RUN_TIMEOUT = 120
 DOCKER_RESTART_TIMEOUT = 30
 
+# Timeout for the user to complete Codex device-auth (seconds).
+CODEX_DEVICE_AUTH_TIMEOUT = 300  # 5 minutes
+
 # ---------------------------------------------------------------------------
 # DAG definition
 # ---------------------------------------------------------------------------
@@ -65,10 +75,10 @@ default_args = {
 @dag(
     dag_id="credential_keepalive",
     description=(
-        "Proactively refreshes LLM CLI OAuth tokens every 4 hours and "
+        "Proactively refreshes LLM CLI OAuth tokens every hour and "
         "restarts the go-worker if it was stuck in a credential-error state."
     ),
-    schedule="0 */4 * * *",
+    schedule="0 * * * *",
     start_date=datetime(2026, 3, 25),
     catchup=False,
     tags=["project:customclaw", "credential-management", "automated"],
@@ -315,11 +325,213 @@ def credential_keepalive() -> None:
         )
 
     # ------------------------------------------------------------------
+    # Task 4: Check Codex CLI authentication
+    # ------------------------------------------------------------------
+
+    @task()
+    def check_codex() -> dict:
+        """Test Codex CLI authentication by making a minimal API call.
+
+        Runs a trivial ``codex exec`` inside the go-worker container.  A 401 /
+        Unauthorized response or non-zero exit code indicates that the ChatGPT
+        OAuth token has expired.
+
+        Returns:
+            Dict with keys:
+            - ``healthy`` (bool): Whether the auth check passed.
+            - ``error`` (str): Short error description when unhealthy.
+        """
+        cmd = [
+            "docker", "exec",
+            "-e", "HOME=/home/appuser",
+            "-e", "NO_COLOR=1",
+            GO_WORKER_CONTAINER,
+            "codex", "exec", "hi",
+            "-m", "gpt-5.4",
+            "--dangerously-bypass-approvals-and-sandbox",
+        ]
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=60,
+                stdin=subprocess.DEVNULL,
+            )
+        except subprocess.TimeoutExpired:
+            log.warning("Codex auth check timed out.")
+            return {"healthy": False, "error": "timeout"}
+        except FileNotFoundError:
+            return {"healthy": False, "error": "docker not found"}
+
+        combined = result.stdout + result.stderr
+        if result.returncode != 0 or "401" in combined or "Unauthorized" in combined:
+            error_msg = result.stderr.strip()[:300] or result.stdout.strip()[:300]
+            log.error("Codex auth check failed: %s", error_msg)
+            return {"healthy": False, "error": error_msg}
+
+        log.info("Codex auth check passed.")
+        log.info("Codex token warmup successful — access token refreshed.")
+        return {"healthy": True}
+
+    # ------------------------------------------------------------------
+    # Task 5: Recover Codex auth via device-auth flow
+    # ------------------------------------------------------------------
+
+    @task()
+    def recover_codex(codex_result: dict) -> None:
+        """If Codex auth failed, initiate device-auth flow and send code to Slack.
+
+        Starts ``codex login --device-auth`` inside the go-worker container,
+        reads the device code + URL from its output, and posts them to Slack so
+        the operator can authenticate within the 5-minute window.  Waits for the
+        process to complete before returning.
+
+        Args:
+            codex_result: Dict from ``check_codex`` with keys ``healthy`` and
+                ``error``.
+        """
+        if codex_result.get("healthy", True):
+            log.info("Codex auth is healthy — no recovery needed.")
+            return
+
+        log.info("Codex auth failed — initiating device-auth recovery flow.")
+
+        slack_token = _resolve_slack_token()
+        try:
+            channel = Variable.get(SLACK_ALERT_CHANNEL_VAR, default=DEFAULT_ALERT_CHANNEL)
+        except Exception:
+            channel = DEFAULT_ALERT_CHANNEL
+
+        # Start codex login --device-auth in the go-worker container.
+        cmd = [
+            "docker", "exec",
+            "-e", "HOME=/home/appuser",
+            GO_WORKER_CONTAINER,
+            "codex", "login", "--device-auth",
+        ]
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                stdin=subprocess.DEVNULL,
+            )
+        except FileNotFoundError:
+            log.error("docker binary not found — cannot initiate device-auth.")
+            raise AirflowFailException("docker not found for Codex device-auth")
+
+        # Read output lines to find device code and URL.
+        # Typical output: "Go to https://login.live.com/... and enter code XXXX-XXXX"
+        device_info_lines: list[str] = []
+        start_time = time.time()
+        full_output: list[str] = []
+
+        while time.time() - start_time < CODEX_DEVICE_AUTH_TIMEOUT:
+            if proc.poll() is not None:
+                # Process finished — drain remaining output.
+                remaining = proc.stdout.read()
+                if remaining:
+                    full_output.append(remaining)
+                break
+
+            try:
+                line = proc.stdout.readline()
+                if line:
+                    full_output.append(line)
+                    line_stripped = line.strip()
+                    log.info("codex login output: %s", line_stripped)
+                    # Capture lines that carry the URL or device code.
+                    if any(
+                        kw in line_stripped.lower()
+                        for kw in ["http", "code", "enter", "visit", "go to", "url"]
+                    ):
+                        device_info_lines.append(line_stripped)
+            except Exception:
+                time.sleep(1)
+                continue
+
+        output_text = "".join(full_output).strip()
+
+        if proc.poll() is None:
+            # Still running after timeout — kill it.
+            proc.kill()
+            proc.wait()
+            log.error(
+                "Codex device-auth timed out after %ds.", CODEX_DEVICE_AUTH_TIMEOUT
+            )
+
+            # Still send whatever device info we captured so the operator can
+            # complete auth manually.
+            if device_info_lines and slack_token:
+                device_msg = "\n".join(device_info_lines)
+                text = (
+                    ":key: *Codex Device Auth Required*\n"
+                    "돌쇠(Discord) 봇의 OpenAI 인증이 만료되었습니다.\n"
+                    "아래 URL에서 코드를 입력해주세요:\n"
+                    f"```{device_msg}```\n"
+                    f"_(인증 대기 {CODEX_DEVICE_AUTH_TIMEOUT}초 초과 — 수동으로 완료 필요)_\n"
+                    "```ssh ubuntu24_home_server-ext\n"
+                    "docker exec -it -e HOME=/home/appuser customclaw-go-worker-1 "
+                    "codex login --device-auth```"
+                )
+                _send_slack_alert(token=slack_token, channel=channel, output=text)
+            raise AirflowFailException(
+                f"Codex device-auth timed out. "
+                f"Device info: {' | '.join(device_info_lines)}"
+            )
+
+        # Process completed within the timeout window.
+        if proc.returncode == 0:
+            log.info("Codex device-auth completed successfully!")
+            if slack_token:
+                _send_slack_alert(
+                    token=slack_token,
+                    channel=channel,
+                    output=(
+                        ":white_check_mark: *Codex 인증 복구 완료*\n"
+                        "돌쇠 봇이 정상 동작합니다."
+                    ),
+                )
+        else:
+            log.error(
+                "Codex device-auth failed (exit %d): %s",
+                proc.returncode,
+                output_text[:300],
+            )
+            if slack_token and device_info_lines:
+                device_msg = "\n".join(device_info_lines)
+                text = (
+                    ":rotating_light: *Codex OAuth 인증 만료*\n"
+                    "돌쇠(Discord) 봇이 응답하지 않습니다.\n"
+                    "아래 URL에서 인증해주세요:\n"
+                    f"```{device_msg}```"
+                )
+                _send_slack_alert(token=slack_token, channel=channel, output=text)
+            elif slack_token:
+                _send_slack_alert(
+                    token=slack_token,
+                    channel=channel,
+                    output=(
+                        ":rotating_light: *Codex OAuth 인증 만료*\n"
+                        "돌쇠 봇이 응답하지 않습니다. 수동 로그인 필요:\n"
+                        "```ssh ubuntu24_home_server-ext\n"
+                        "docker exec -it -e HOME=/home/appuser "
+                        "customclaw-go-worker-1 codex login --device-auth```"
+                    ),
+                )
+            raise AirflowFailException(
+                f"Codex device-auth failed: {output_text[:200]}"
+            )
+
+    # ------------------------------------------------------------------
     # Wire up the task graph
     # ------------------------------------------------------------------
     statuses = check_status()
     refresh_result = refresh_claude(statuses)
     verify_and_alert(refresh_result)
+
+    codex_result = check_codex()
+    recover_codex(codex_result)
 
 
 # ---------------------------------------------------------------------------

--- a/dags/shared/slack_bolt_healthcheck.py
+++ b/dags/shared/slack_bolt_healthcheck.py
@@ -1,0 +1,394 @@
+"""Slack Bolt Container Healthcheck DAG.
+
+Monitors the ``customclaw-slack-bolt-1`` container for a BrokenPipeError
+reconnection loop.  The container does not self-exit when this happens, so the
+Docker restart policy never fires.  This DAG detects the loop and force-restarts
+the container.
+
+Detection heuristic: if ``BrokenPipeError`` appears 3 or more times in the last
+20 log lines, the container is considered stuck and is restarted.
+
+Graph:
+    check_logs ─► restart_if_looping ─► send_alert
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from datetime import datetime, timedelta
+
+import requests
+from airflow.sdk import Variable, dag, task
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Target container to monitor and restart.
+SLACK_BOLT_CONTAINER = "customclaw-slack-bolt-1"
+
+# Number of trailing log lines to inspect on each run.
+LOG_TAIL_LINES = 20
+
+# How many occurrences of BrokenPipeError in the tail before we restart.
+BROKEN_PIPE_THRESHOLD = 3
+
+# Airflow Variable / env-var names (shared with credential_keepalive).
+SLACK_TOKEN_VAR = "customclaw_slack_bot_token"
+SLACK_ALERT_CHANNEL_VAR = "credential_alert_channel"
+DEFAULT_ALERT_CHANNEL = "C0AMBNY135Z"
+
+# Timeout for docker commands (seconds).
+DOCKER_LOGS_TIMEOUT = 15
+DOCKER_RESTART_TIMEOUT = 30
+
+# ---------------------------------------------------------------------------
+# DAG definition
+# ---------------------------------------------------------------------------
+default_args = {
+    "owner": "customclaw",
+    # No retries: each 5-minute tick is a fresh check; retrying a health-check
+    # after failure would just re-check the same already-restarted container.
+    "retries": 0,
+}
+
+
+@dag(
+    dag_id="slack_bolt_healthcheck",
+    description=(
+        "Every 5 minutes, inspects the last 20 log lines of customclaw-slack-bolt-1. "
+        "If BrokenPipeError appears 3+ times the container is restarted and a Slack "
+        "alert is posted to the credential alert channel."
+    ),
+    schedule="*/5 * * * *",
+    start_date=datetime(2026, 3, 25),
+    catchup=False,
+    tags=["monitoring", "platform"],
+    default_args=default_args,
+    doc_md=__doc__,
+)
+def slack_bolt_healthcheck() -> None:
+    """Orchestrate the healthcheck and optional restart of the slack-bolt container."""
+
+    # ------------------------------------------------------------------
+    # Task 1: Fetch the last N log lines from the container
+    # ------------------------------------------------------------------
+
+    @task()
+    def check_logs() -> dict:
+        """Retrieve the last log lines from the slack-bolt container.
+
+        Runs ``docker logs --tail {LOG_TAIL_LINES}`` against the target
+        container.  If docker is unavailable or the command fails for any
+        reason the task logs a warning and returns an empty result rather
+        than failing the DAG run.
+
+        Returns:
+            Dict with keys:
+
+            - ``lines`` (list[str]): Individual log lines (stdout + stderr merged).
+            - ``broken_pipe_count`` (int): Occurrences of ``BrokenPipeError`` in
+              those lines.
+            - ``docker_available`` (bool): False when the docker binary was not
+              found.
+        """
+        cmd = [
+            "docker",
+            "logs",
+            "--tail",
+            str(LOG_TAIL_LINES),
+            SLACK_BOLT_CONTAINER,
+        ]
+
+        try:
+            # docker logs writes to stderr by default; capture both streams.
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=DOCKER_LOGS_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            log.warning(
+                "docker logs timed out after %ds for %s.",
+                DOCKER_LOGS_TIMEOUT,
+                SLACK_BOLT_CONTAINER,
+            )
+            return {"lines": [], "broken_pipe_count": 0, "docker_available": True}
+        except FileNotFoundError:
+            log.warning("docker binary not found — cannot fetch container logs.")
+            return {"lines": [], "broken_pipe_count": 0, "docker_available": False}
+
+        if result.returncode != 0:
+            log.warning(
+                "docker logs exited %d for %s. stderr: %s",
+                result.returncode,
+                SLACK_BOLT_CONTAINER,
+                result.stderr[:300],
+            )
+            return {"lines": [], "broken_pipe_count": 0, "docker_available": True}
+
+        # docker logs emits to stderr; stdout may be empty depending on the
+        # container's logging driver.  Merge both so we don't miss anything.
+        combined = (result.stdout + result.stderr).strip()
+        lines = combined.splitlines() if combined else []
+
+        broken_pipe_count = sum(
+            1 for line in lines if "BrokenPipeError" in line
+        )
+
+        log.info(
+            "Fetched %d log lines from %s. BrokenPipeError occurrences: %d/%d threshold.",
+            len(lines),
+            SLACK_BOLT_CONTAINER,
+            broken_pipe_count,
+            BROKEN_PIPE_THRESHOLD,
+        )
+        if lines:
+            log.debug("Last log line: %s", lines[-1])
+
+        return {
+            "lines": lines,
+            "broken_pipe_count": broken_pipe_count,
+            "docker_available": True,
+        }
+
+    # ------------------------------------------------------------------
+    # Task 2: Restart the container if the loop is detected
+    # ------------------------------------------------------------------
+
+    @task()
+    def restart_if_looping(log_result: dict) -> dict:
+        """Restart the slack-bolt container if a BrokenPipeError loop is detected.
+
+        A restart is triggered only when ``broken_pipe_count`` meets or exceeds
+        ``BROKEN_PIPE_THRESHOLD``.  On any docker command failure the error is
+        logged but the task does not raise so the alert task still runs.
+
+        Args:
+            log_result: Dict produced by ``check_logs``.
+
+        Returns:
+            Dict with keys:
+
+            - ``restarted`` (bool): True if a restart was attempted.
+            - ``restart_success`` (bool): True if docker restart returned exit 0.
+            - ``broken_pipe_count`` (int): Forwarded from ``log_result``.
+            - ``reason`` (str): Human-readable reason for the action taken.
+        """
+        broken_pipe_count: int = log_result.get("broken_pipe_count", 0)
+        docker_available: bool = log_result.get("docker_available", True)
+
+        if not docker_available:
+            log.warning("Skipping restart check: docker is unavailable.")
+            return {
+                "restarted": False,
+                "restart_success": False,
+                "broken_pipe_count": broken_pipe_count,
+                "reason": "docker_unavailable",
+            }
+
+        if broken_pipe_count < BROKEN_PIPE_THRESHOLD:
+            log.info(
+                "Container %s appears healthy (BrokenPipeError: %d/%d).",
+                SLACK_BOLT_CONTAINER,
+                broken_pipe_count,
+                BROKEN_PIPE_THRESHOLD,
+            )
+            return {
+                "restarted": False,
+                "restart_success": False,
+                "broken_pipe_count": broken_pipe_count,
+                "reason": "healthy",
+            }
+
+        log.warning(
+            "BrokenPipeError loop detected in %s (%d occurrences in last %d lines). "
+            "Triggering container restart.",
+            SLACK_BOLT_CONTAINER,
+            broken_pipe_count,
+            LOG_TAIL_LINES,
+        )
+
+        try:
+            result = subprocess.run(
+                ["docker", "restart", SLACK_BOLT_CONTAINER],
+                capture_output=True,
+                text=True,
+                timeout=DOCKER_RESTART_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            log.error(
+                "docker restart timed out after %ds for %s.",
+                DOCKER_RESTART_TIMEOUT,
+                SLACK_BOLT_CONTAINER,
+            )
+            return {
+                "restarted": True,
+                "restart_success": False,
+                "broken_pipe_count": broken_pipe_count,
+                "reason": "restart_timeout",
+            }
+        except FileNotFoundError:
+            log.error("docker binary not found — cannot restart %s.", SLACK_BOLT_CONTAINER)
+            return {
+                "restarted": True,
+                "restart_success": False,
+                "broken_pipe_count": broken_pipe_count,
+                "reason": "docker_unavailable",
+            }
+
+        if result.returncode != 0:
+            log.error(
+                "docker restart %s failed (exit %d): %s",
+                SLACK_BOLT_CONTAINER,
+                result.returncode,
+                result.stderr[:300],
+            )
+            return {
+                "restarted": True,
+                "restart_success": False,
+                "broken_pipe_count": broken_pipe_count,
+                "reason": f"restart_failed_exit_{result.returncode}",
+            }
+
+        log.info(
+            "Successfully restarted %s after detecting BrokenPipeError loop.",
+            SLACK_BOLT_CONTAINER,
+        )
+        return {
+            "restarted": True,
+            "restart_success": True,
+            "broken_pipe_count": broken_pipe_count,
+            "reason": "loop_detected_and_restarted",
+        }
+
+    # ------------------------------------------------------------------
+    # Task 3: Send a Slack alert when a restart was performed
+    # ------------------------------------------------------------------
+
+    @task()
+    def send_alert(restart_result: dict) -> None:
+        """Post a Slack alert when the container was restarted.
+
+        No message is sent during healthy (no-restart) runs to avoid noise.
+        If a restart occurred (successfully or not), an alert is posted to
+        the credential alert channel.  Alert failure is logged but does not
+        fail the DAG.
+
+        Args:
+            restart_result: Dict from ``restart_if_looping``.
+        """
+        restarted: bool = restart_result.get("restarted", False)
+        if not restarted:
+            log.info("No restart was triggered — skipping alert.")
+            return
+
+        restart_success: bool = restart_result.get("restart_success", False)
+        broken_pipe_count: int = restart_result.get("broken_pipe_count", 0)
+        reason: str = restart_result.get("reason", "unknown")
+
+        if restart_success:
+            status_emoji = ":white_check_mark:"
+            status_text = "Container restarted successfully."
+        else:
+            status_emoji = ":x:"
+            status_text = f"Restart *failed* (reason: `{reason}`). Manual intervention required."
+
+        text = (
+            f":warning: *Slack Bolt Container Healthcheck*\n"
+            f"*Container:* `{SLACK_BOLT_CONTAINER}`\n"
+            f"*Trigger:* `BrokenPipeError` appeared *{broken_pipe_count}x* "
+            f"in the last {LOG_TAIL_LINES} log lines (threshold: {BROKEN_PIPE_THRESHOLD}).\n"
+            f"{status_emoji} {status_text}"
+        )
+
+        slack_token = _resolve_slack_token()
+        if not slack_token:
+            log.warning(
+                "No Slack token available — cannot send restart alert. "
+                "Container restart status: %s",
+                "success" if restart_success else "failed",
+            )
+            return
+
+        try:
+            channel = Variable.get(SLACK_ALERT_CHANNEL_VAR, default=DEFAULT_ALERT_CHANNEL)
+        except Exception:
+            channel = DEFAULT_ALERT_CHANNEL
+
+        _send_slack_message(token=slack_token, channel=channel, text=text)
+
+    # ------------------------------------------------------------------
+    # Wire up the task graph
+    # ------------------------------------------------------------------
+    log_result = check_logs()
+    restart_result = restart_if_looping(log_result)
+    send_alert(restart_result)
+
+
+# ---------------------------------------------------------------------------
+# Module-level pure helper functions
+# ---------------------------------------------------------------------------
+
+
+def _resolve_slack_token() -> str | None:
+    """Resolve the Slack bot token from Airflow Variable or environment.
+
+    Lookup order:
+    1. Airflow Variable ``customclaw_slack_bot_token``
+    2. Environment variable ``CUSTOMCLAW_SLACK_BOT_TOKEN``
+
+    Returns:
+        Token string if found, ``None`` otherwise.
+    """
+    # 1. Airflow Variable (preferred)
+    try:
+        token = Variable.get(SLACK_TOKEN_VAR, default=None)
+        if token:
+            return token
+    except Exception:
+        pass
+
+    # 2. Direct environment variable
+    return os.environ.get("CUSTOMCLAW_SLACK_BOT_TOKEN") or None
+
+
+def _send_slack_message(token: str, channel: str, text: str) -> None:
+    """Post a message to a Slack channel via the chat.postMessage API.
+
+    Errors are logged but not re-raised so they never fail the DAG.
+
+    Args:
+        token: Slack bot OAuth token.
+        channel: Slack channel ID.
+        text: Message body (supports mrkdwn).
+    """
+    try:
+        resp = requests.post(
+            "https://slack.com/api/chat.postMessage",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json={"channel": channel, "text": text},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("ok"):
+            log.error(
+                "Slack API returned ok=false: %s", data.get("error", "unknown")
+            )
+        else:
+            log.info("Slack alert sent to channel %s.", channel)
+    except requests.exceptions.RequestException as exc:
+        log.error("Failed to send Slack alert: %s", exc)
+
+
+# Instantiate the DAG
+dag_instance = slack_bolt_healthcheck()

--- a/go/internal/llm/anthropic.go
+++ b/go/internal/llm/anthropic.go
@@ -69,7 +69,7 @@ func (p *ClaudeProvider) Complete(ctx context.Context, req *Request) (*Response,
 	model := resolveClaudeModel(req.Model)
 	maxTurns := req.MaxTurns
 	if maxTurns == 0 {
-		maxTurns = 3
+		maxTurns = 5
 	}
 
 	// Build combined prompt: the Claude CLI takes a single -p argument.

--- a/web-ui/src/app/(auth)/airflow/page.tsx
+++ b/web-ui/src/app/(auth)/airflow/page.tsx
@@ -155,7 +155,9 @@ function SummaryStatsBar({ dags }: { dags: Dag[] }) {
   const total = dags.length;
   const active = dags.filter((d) => !d.is_paused).length;
   const running = dags.filter((d) => d.last_run_state === "running").length;
-  const failed = dags.filter((d) => d.last_run_state === "failed").length;
+  const failed = dags.filter(
+    (d) => d.last_run_state === "failed" || d.last_run_state === "upstream_failed"
+  ).length;
 
   const stats = [
     {

--- a/web-ui/src/app/(auth)/bots/page.tsx
+++ b/web-ui/src/app/(auth)/bots/page.tsx
@@ -43,6 +43,13 @@ interface BotData {
 }
 
 function getChannelCount(bot: BotData): number {
+  // Discord bots: check discord-specific config for guild/channel info
+  if (bot.platform === "discord") {
+    const discord = (bot as unknown as Record<string, unknown>).discord as Record<string, unknown> | undefined;
+    if (discord?.guild_id) return 1; // Connected to 1 guild
+    return 0;
+  }
+  // Slack bots: existing logic
   if (bot.channels?.length > 0) return bot.channels.length;
   if ((bot.security?.allowed_channels?.length ?? 0) > 0)
     return bot.security!.allowed_channels!.length;

--- a/web-ui/src/app/api/airflow/dags/route.ts
+++ b/web-ui/src/app/api/airflow/dags/route.ts
@@ -26,7 +26,10 @@ export async function GET() {
           const runRes = await airflowFetch(
             `/dags/${dag.dag_id}/dagRuns?limit=1&order_by=-start_date`
           );
-          if (!runRes.ok) return { ...dag, last_run: null, last_run_state: null };
+          if (!runRes.ok) {
+            console.warn(`dagRuns API error for ${dag.dag_id}: ${runRes.status}`);
+            return { ...dag, last_run: null, last_run_state: null };
+          }
           const runData = await runRes.json();
           const lastRun = runData.dag_runs?.[0];
           return {
@@ -34,7 +37,8 @@ export async function GET() {
             last_run: lastRun?.start_date ?? null,
             last_run_state: lastRun?.state ?? null,
           };
-        } catch {
+        } catch (err) {
+          console.error(`dagRuns fetch failed for ${dag.dag_id}:`, err);
           return { ...dag, last_run: null, last_run_state: null };
         }
       })


### PR DESCRIPTION
## Summary
- **#39**: Airflow dashboard failed DAG count — added API error logging + upstream_failed state
- **#36**: maxTurns fallback 3→5 in anthropic.go
- **#34**: Discord bot channel count — platform-aware getChannelCount()
- **credential_keepalive**: hourly schedule + Codex OAuth health check with device-auth recovery
- **slack_bolt_healthcheck**: new DAG — monitors BrokenPipeError, auto-restarts container

## Changes
| File | Change |
|------|--------|
| `anthropic.go` | maxTurns fallback 3→5 |
| `route.ts` | dagRuns API error logging |
| `airflow/page.tsx` | upstream_failed in failed count |
| `bots/page.tsx` | Discord guild-based channel count |
| `credential_keepalive.py` | Hourly schedule + Codex check + device-auth recovery |
| `slack_bolt_healthcheck.py` | New DAG — BrokenPipeError monitor |

## Test plan
- [x] `go build/vet/test` all pass
- [x] `npm run build` (web-ui) passes
- [x] credential_keepalive deployed and running on production
- [x] slack_bolt_healthcheck deployed and running on production
- [ ] CI checks (lint, build-and-test, docker)

Closes #39
Closes #36
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)