### PR TITLE
fix: harden Codex OAuth token expiry detection and path resolution

### DIFF
--- a/docker-compose.go-shadow.yml
+++ b/docker-compose.go-shadow.yml
@@ -47,6 +47,7 @@ services:
       BOTS_DIR: /app/bots
       HOME: ${CONTAINER_HOME}
       CONTAINER_HOME: ${CONTAINER_HOME}
+      CODEX_CONFIG_DIR: ${CONTAINER_HOME}/.codex
       # Claude OAuth
       CLAUDE_CREDENTIALS_PATH: ${CONTAINER_HOME}/.claude/.credentials.json
       # Codex CLI

--- a/go/docker-compose.go-worker.yml
+++ b/go/docker-compose.go-worker.yml
@@ -18,6 +18,7 @@ services:
       MERGE_WINDOW_SECONDS: "30"
       # All LLM providers use CLI subprocess — set HOME for credential resolution
       CONTAINER_HOME: /home/appuser
+      CODEX_CONFIG_DIR: /home/appuser/.codex
       # Claude CLI
       CLAUDE_CLI_PATH: /usr/local/bin/claude
       # Codex CLI subprocess provider

--- a/go/internal/tokenrefresh/codex.go
+++ b/go/internal/tokenrefresh/codex.go
@@ -28,13 +28,47 @@ const (
 //  1. CODEX_CONFIG_DIR/auth.json
 //  2. CONTAINER_HOME/.codex/auth.json
 func codexCredPath() (string, error) {
+	var primary string
 	if dir := os.Getenv("CODEX_CONFIG_DIR"); dir != "" {
-		return filepath.Join(dir, "auth.json"), nil
+		primary = filepath.Join(dir, "auth.json")
 	}
+
+	var fallback string
 	if home := os.Getenv("CONTAINER_HOME"); home != "" {
-		return filepath.Join(home, ".codex", "auth.json"), nil
+		fallback = filepath.Join(home, ".codex", "auth.json")
+	}
+
+	if existingRegularFile(primary) {
+		return primary, nil
+	}
+	if existingRegularFile(fallback) {
+		if primary != "" && primary != fallback {
+			slog.Warn("codex auth path mismatch; using CONTAINER_HOME fallback",
+				"configured_path", primary,
+				"fallback_path", fallback,
+			)
+		}
+		return fallback, nil
+	}
+
+	if primary != "" {
+		return primary, nil
+	}
+	if fallback != "" {
+		return fallback, nil
 	}
 	return "", fmt.Errorf("none of CODEX_CONFIG_DIR or CONTAINER_HOME is set")
+}
+
+func existingRegularFile(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
 }
 
 // jwtExpiry decodes the payload of a JWT (without signature verification) and
@@ -47,7 +81,7 @@ func jwtExpiry(token string) (int64, error) {
 	}
 
 	// JWT payload uses base64url encoding without padding.
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	payload, err := decodeJWTPayload(parts[1])
 	if err != nil {
 		return 0, fmt.Errorf("decode JWT payload: %w", err)
 	}
@@ -64,17 +98,36 @@ func jwtExpiry(token string) (int64, error) {
 	return claims.Exp, nil
 }
 
+func decodeJWTPayload(payloadPart string) ([]byte, error) {
+	if payload, err := base64.RawURLEncoding.DecodeString(payloadPart); err == nil {
+		return payload, nil
+	}
+	return base64.URLEncoding.DecodeString(payloadPart)
+}
+
 // codexNeedsRefresh reports whether the access token in creds should be
 // refreshed: either parsing fails (treat as expired) or the token expires
 // within codexRefreshWindow.
 func codexNeedsRefresh(creds *codexCredentials) bool {
-	exp, err := jwtExpiry(creds.Tokens.AccessToken)
+	accessExp, err := jwtExpiry(creds.Tokens.AccessToken)
 	if err != nil {
 		slog.Warn("codex: could not parse access token expiry; assuming refresh needed", "error", err)
 		return true
 	}
-	expiresAt := time.Unix(exp, 0)
-	return time.Until(expiresAt) < codexRefreshWindow
+	if time.Until(time.Unix(accessExp, 0)) < codexRefreshWindow {
+		return true
+	}
+
+	idToken := strings.TrimSpace(creds.Tokens.IDToken)
+	if idToken == "" {
+		return false
+	}
+	idExp, err := jwtExpiry(idToken)
+	if err != nil {
+		slog.Warn("codex: could not parse id token expiry; assuming refresh needed", "error", err)
+		return true
+	}
+	return time.Until(time.Unix(idExp, 0)) < codexRefreshWindow
 }
 
 // refreshCodex loads the Codex auth file, checks whether a refresh is needed,
@@ -104,7 +157,12 @@ func refreshCodex(ctx context.Context) (bool, error) {
 		"expires_at", time.Unix(exp, 0).Format(time.RFC3339),
 	)
 
-	resp, err := doCodexRefresh(ctx, creds.Tokens.RefreshToken)
+	refreshToken := strings.TrimSpace(creds.Tokens.RefreshToken)
+	if refreshToken == "" {
+		return false, fmt.Errorf("codex credentials missing refresh_token")
+	}
+
+	resp, err := doCodexRefresh(ctx, refreshToken)
 	if err != nil {
 		return false, fmt.Errorf("codex token refresh request: %w", err)
 	}

--- a/go/internal/tokenrefresh/refresh_test.go
+++ b/go/internal/tokenrefresh/refresh_test.go
@@ -21,6 +21,13 @@ func makeJWT(exp int64) string {
 	return header + "." + payload + ".sig"
 }
 
+func makeJWTPadded(exp int64) string {
+	header := base64.URLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims, _ := json.Marshal(map[string]int64{"exp": exp})
+	payload := base64.URLEncoding.EncodeToString(claims)
+	return header + "." + payload + ".sig"
+}
+
 func TestJWTExpiry_Valid(t *testing.T) {
 	want := int64(9999999999)
 	token := makeJWT(want)
@@ -47,6 +54,18 @@ func TestJWTExpiry_MissingExp(t *testing.T) {
 	_, err := jwtExpiry(token)
 	if err == nil {
 		t.Error("expected error when exp claim is absent")
+	}
+}
+
+func TestJWTExpiry_PaddedBase64(t *testing.T) {
+	want := int64(2233445566)
+	token := makeJWTPadded(want)
+	got, err := jwtExpiry(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got exp %d, want %d", got, want)
 	}
 }
 
@@ -144,6 +163,34 @@ func TestCodexNeedsRefresh_MalformedToken(t *testing.T) {
 	// Malformed token should be treated as needing refresh.
 	if !codexNeedsRefresh(creds) {
 		t.Error("expected needs refresh for malformed token")
+	}
+}
+
+func TestCodexNeedsRefresh_IDTokenExpired(t *testing.T) {
+	accessExp := time.Now().Add(48 * time.Hour).Unix()
+	idExp := time.Now().Add(-5 * time.Minute).Unix()
+	creds := &codexCredentials{
+		Tokens: codexTokens{
+			AccessToken: makeJWT(accessExp),
+			IDToken:     makeJWT(idExp),
+		},
+	}
+	if !codexNeedsRefresh(creds) {
+		t.Error("expected needs refresh when id token is already expired")
+	}
+}
+
+func TestCodexNeedsRefresh_IDTokenValid(t *testing.T) {
+	accessExp := time.Now().Add(48 * time.Hour).Unix()
+	idExp := time.Now().Add(48 * time.Hour).Unix()
+	creds := &codexCredentials{
+		Tokens: codexTokens{
+			AccessToken: makeJWT(accessExp),
+			IDToken:     makeJWT(idExp),
+		},
+	}
+	if codexNeedsRefresh(creds) {
+		t.Error("expected no refresh needed when both access and id token are valid")
 	}
 }
 
@@ -370,5 +417,31 @@ func TestClaudeCredPath_NoneSet(t *testing.T) {
 	_, err := claudeCredPath()
 	if err == nil {
 		t.Error("expected error when no env vars are set")
+	}
+}
+
+func TestCodexCredPath_PrefersExistingFallbackFile(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "host-codex")
+	homeDir := filepath.Join(dir, "home")
+	homeCodexDir := filepath.Join(homeDir, ".codex")
+
+	if err := os.MkdirAll(homeCodexDir, 0o755); err != nil {
+		t.Fatalf("mkdir home codex dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(homeCodexDir, "auth.json"), []byte(`{"tokens":{}}`), 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+
+	t.Setenv("CODEX_CONFIG_DIR", configDir)
+	t.Setenv("CONTAINER_HOME", homeDir)
+
+	p, err := codexCredPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(homeCodexDir, "auth.json")
+	if p != want {
+		t.Errorf("got %q, want %q", p, want)
 	}
 }


### PR DESCRIPTION
## Summary

- `CODEX_CONFIG_DIR` 환경변수를 `docker-compose.go-shadow.yml` 및 `go/docker-compose.go-worker.yml`에 명시적으로 추가
- `codexCredPath()`가 파일 존재 여부를 확인하고 유효한 경로로 폴백하도록 개선
- `access_token`뿐 아니라 `id_token` 만료도 감지하여 refresh 트리거
- JWT base64 패딩 유무 모두 파싱 가능하도록 수정
- 빈 `refresh_token`을 조기 감지하여 불필요한 refresh 시도 차단

## Test plan

- [ ] `go test ./go/internal/tokenrefresh/...` — 추가된 회귀 테스트 3개 포함 전체 통과 확인
- [ ] `go vet ./go/...` — 정적 분석 클린 확인
- [ ] docker-compose로 go-worker 컨테이너 기동 후 Codex 토큰 만료 시나리오 수동 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)